### PR TITLE
New samples, tests, and benchmarks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,55 @@
+---
+Language:        Cpp
+Standard:        c++14
+
+
+# The following is close to the style we've been using all these years
+# without formalizing it.  Formatting won't be enforced, but this file
+# can help if you want to use the general feel of the library.
+
+
+# General appearance:
+
+BasedOnStyle: LLVM
+
+IndentWidth: 4
+ColumnLimit: 100
+NamespaceIndentation: All
+MaxEmptyLinesToKeep: 2
+FixNamespaceComments: false
+
+# Function declarations:
+
+BinPackParameters: false
+AllowShortFunctionsOnASingleLine: Inline
+AlwaysBreakTemplateDeclarations: true
+
+# T& x, not T &x:
+
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+# QuantLib headers first, then Boost, then std
+
+SortIncludes: true
+IncludeBlocks: Merge
+IncludeCategories: 
+  - Regex:           '^"'
+    Priority:        1
+  - Regex:           '^<ql/'
+    Priority:        2
+  - Regex:           '^<boost/'
+    Priority:        3
+  - Regex:           '^<'
+    Priority:        4
+
+# Other:
+
+AlignEscapedNewlines: Left
+BreakBeforeTernaryOperators: false
+ConstructorInitializerIndentWidth: 0
+SortUsingDeclarations: false
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+
+...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,12 @@ env:
   xad_repo: ${{ github.event.inputs.xad_repo || 'xcelerit/XAD' }}
   xad_branch: ${{ github.event.inputs.xad_branch || 'main' }}
 jobs:
+
   xad-linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        disable_aad: ["ON", "OFF"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -63,7 +68,7 @@ jobs:
         cd QuantLib
         mkdir build
         cd build
-        cmake -G Ninja -DBOOST_ROOT=/usr -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQL_EXTERNAL_SUBDIRECTORIES="${{ github.workspace }}/XAD;${{ github.workspace }}/qlxad" -DQL_EXTRA_LINK_LIBRARIES=qlxad -DQL_NULL_AS_FUNCTIONS=ON ..
+        cmake -G Ninja -DBOOST_ROOT=/usr -DQLXAD_DISABLE_AAD=${{ matrix.disable_aad }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQL_EXTERNAL_SUBDIRECTORIES="${{ github.workspace }}/XAD;${{ github.workspace }}/qlxad" -DQL_EXTRA_LINK_LIBRARIES=qlxad -DQL_NULL_AS_FUNCTIONS=ON ..
     - name: Compile
       run: |
         cd QuantLib/build
@@ -76,7 +81,13 @@ jobs:
       run: |
         cd QuantLib/build
         ./qlxad/test-suite/quantlib-xad-test-suite --log_level=message
+
+
   xad-win:
+    strategy:
+      fail-fast: false
+      matrix:
+        disable_aad: ["ON", "OFF"]
     runs-on: windows-2022
     env:
       vsvarsall: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat
@@ -115,7 +126,7 @@ jobs:
         mkdir build
         cd build
         call "${{ env.vsvarsall }}" amd64 -vcvars_ver=14.3
-        cmake .. -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_BUILD_TYPE=Release -DQL_EXTERNAL_SUBDIRECTORIES="${{ github.workspace }}/XAD;${{ github.workspace }}/qlxad" -DQL_EXTRA_LINK_LIBRARIES=qlxad -DQL_NULL_AS_FUNCTIONS=ON -DXAD_STATIC_MSVC_RUNTIME=ON
+        cmake .. -G Ninja -DQLXAD_DISABLE_AAD=${{ matrix.disable_aad }} -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_BUILD_TYPE=Release -DQL_EXTERNAL_SUBDIRECTORIES="${{ github.workspace }}/XAD;${{ github.workspace }}/qlxad" -DQL_EXTRA_LINK_LIBRARIES=qlxad -DQL_NULL_AS_FUNCTIONS=ON -DXAD_STATIC_MSVC_RUNTIME=ON
     - name: Build
       shell: cmd
       run: |
@@ -134,7 +145,13 @@ jobs:
         cd QuantLib\build
         call "${{ env.vsvarsall }}" amd64 -vcvars_ver=14.3
         .\qlxad\test-suite\quantlib-xad-test-suite --log_level=message
+
+
   xad-macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        disable_aad: ["ON", "OFF"]
     runs-on: macos-latest
     env:
       CXXFLAGS: -stdlib=libc++ -mmacosx-version-min=10.9
@@ -167,7 +184,7 @@ jobs:
         cd QuantLib
         mkdir build
         cd build
-        cmake -G Ninja -DBOOST_ROOT=/usr -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQL_EXTERNAL_SUBDIRECTORIES="${{ github.workspace }}/XAD;${{ github.workspace }}/qlxad" -DQL_EXTRA_LINK_LIBRARIES=qlxad -DQL_NULL_AS_FUNCTIONS=ON ..
+        cmake -G Ninja -DBOOST_ROOT=/usr -DQLXAD_DISABLE_AAD=${{ matrix.disable_aad }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQL_EXTERNAL_SUBDIRECTORIES="${{ github.workspace }}/XAD;${{ github.workspace }}/qlxad" -DQL_EXTRA_LINK_LIBRARIES=qlxad -DQL_NULL_AS_FUNCTIONS=ON ..
     - name: Compile
       run: |
         cd QuantLib/build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2.5
       with:
-        key: linux
+        key: linux-${{ matrix.disable_aad }}
         max-size: 650M
     - name: Configure
       run: |
@@ -78,6 +78,7 @@ jobs:
         cd QuantLib/build
         ./test-suite/quantlib-test-suite --log_level=message    
     - name: Test QlXAD
+      if: ${{ matrix.disable_aad == 'OFF' }}
       run: |
         cd QuantLib/build
         ./qlxad/test-suite/quantlib-xad-test-suite --log_level=message
@@ -108,7 +109,7 @@ jobs:
     - name: sccache
       uses: hendrikmuhs/ccache-action@v1.2.5
       with:
-        key: windows
+        key: windows-${{ matrix.disable_aad }}
         variant: sccache
         max-size: 650M
     - name: Setup
@@ -140,6 +141,7 @@ jobs:
         call "${{ env.vsvarsall }}" amd64 -vcvars_ver=14.3
         .\test-suite\quantlib-test-suite --log_level=message
     - name: Test QlXAD
+      if: ${{ matrix.disable_aad == 'OFF' }}
       shell: cmd
       run: |
         cd QuantLib\build
@@ -177,7 +179,7 @@ jobs:
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2.5
       with:
-        key: macos
+        key: macos-${{ matrix.disable_aad }}
         max-size: 650M
     - name: Configure
       run: |
@@ -194,6 +196,7 @@ jobs:
         cd QuantLib/build
         ./test-suite/quantlib-test-suite --log_level=message    
     - name: Test QlXAD
+      if: ${{ matrix.disable_aad == 'OFF' }}
       run: |
         cd QuantLib/build
         ./qlxad/test-suite/quantlib-xad-test-suite --log_level=message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Note that we follow QuantLib's releases in this repository, with matching versio
 
 ### Added
 
+- A new CMake option `QLXAD_DISABLE_AAD` to allow running the Examples without AAD
+- A new set of Examples, partially enabled for benchmarking against double
+- Additional tests in the adjoint test suite
+
 ### Changed
 
 ### Deprecated
@@ -24,8 +28,8 @@ Note that we follow QuantLib's releases in this repository, with matching versio
 Initial open-source release, compatible with [QuantLib v1.28](https://github.com/lballabio/QuantLib/releases/tag/QuantLib-v1.28).
 
 
-[unreleased]: https://github.com/xcelerit/qlxad/compare/v1.28...HEAD
+[unreleased]: https://github.com/auto-differentiation/qlxad/compare/v1.28...HEAD
 
-[1.28]: https://github.com/xcelerit/qlxad/tree/v1.28
+[1.28]: https://github.com/auto-differentiation/qlxad/tree/v1.28
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,35 @@
+##############################################################################
+#   
+#
+#  This file is part of qlxad, an adaptor module to enable using XAD with
+#  QuantLib. XAD is a fast and comprehensive C++ library for
+#  automatic differentiation.
+#
+#  Copyright (C) 2010-2023 Xcelerit Computing Ltd.
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   
+##############################################################################
+
+option(QLXAD_DISABLE_AAD "Disable using XAD for QuantLib's Real, allowing to run samples with double" OFF)
+
 add_subdirectory(ql)
 if(MSVC)
 	set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 add_subdirectory(Examples)
-add_subdirectory(test-suite)
+if(NOT QLXAD_DISABLE_AAD)
+    # the test suite is not supporting double
+	add_subdirectory(test-suite)
+endif()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,6 @@ accepted:
 
 This repository follows [QuantLib's coding style](https://www.quantlib.org/style.shtml).
 
-[pr]: https://github.com/xcelerit/qlxad/compare/
+[pr]: https://github.com/auto-differentiation/qlxad/compare/
 
 [cla]: https://gist.github.com/xcelerit-dev/ee51f6c0a3365ae2fc2489e092366de2

--- a/Examples/AdjointAmericanEquityOption/AdjointAmericanEquityOptionXAD.cpp
+++ b/Examples/AdjointAmericanEquityOption/AdjointAmericanEquityOptionXAD.cpp
@@ -1,0 +1,189 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*!
+ Copyright (C) 2023 Xcelerit
+
+ This file is part of QuantLib / XAD integration module.
+ It is modified from QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/* 
+This example demonstrates how to use XAD to price an American equity option
+using the finite different pricing engine and calculate sensitivities
+with XAD.
+*/
+
+#include <ql/qldefines.hpp>
+#if !defined(BOOST_ALL_NO_LIB) && defined(BOOST_MSVC)
+#  include <ql/auto_link.hpp>
+#endif
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/termstructures/volatility/equityfx/blackconstantvol.hpp>
+#include <ql/instruments/vanillaoption.hpp>
+#include <ql/exercise.hpp>
+#include <ql/pricingengines/vanilla/baroneadesiwhaleyengine.hpp>
+#include <ql/pricingengines/vanilla/fdblackscholesvanillaengine.hpp>
+
+#include <vector>
+#include <iostream>
+#include <iomanip>
+
+using namespace QuantLib;
+
+Real priceAmerican(Rate riskFreeRate, const Calendar &calendar,
+                   Date maturity, Real strike, Date settlementDate,
+                   DayCounter dayCounter, Volatility volatility, Date todaysDate,
+                   Spread dividendYield, Option::Type type, Real underlying,
+                   const std::vector<Date> &exerciseDates)
+{
+
+    auto americanExercise = ext::make_shared<AmericanExercise>(settlementDate,
+                             maturity);
+
+    Handle<Quote> underlyingH(ext::make_shared<SimpleQuote>(underlying));
+
+    // bootstrap the yield/dividend/vol curves
+    Handle<YieldTermStructure> flatTermStructure(ext::make_shared<FlatForward>(settlementDate, riskFreeRate, dayCounter));
+    Handle<YieldTermStructure> flatDividendTS(ext::make_shared<FlatForward>(settlementDate, dividendYield, dayCounter));
+    Handle<BlackVolTermStructure> flatVolTS(ext::make_shared<BlackConstantVol>(settlementDate, calendar, volatility,
+                                 dayCounter));
+    auto payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
+    auto bsmProcess = ext::make_shared<BlackScholesMertonProcess>(underlyingH, flatDividendTS,
+                                      flatTermStructure, flatVolTS);
+
+    // options
+    auto american = ext::make_shared<VanillaOption>(
+        payoff,
+        americanExercise);
+    // computing the option price with Finite differences
+    Size timeSteps = 801;
+    american->setPricingEngine(ext::make_shared<FdBlackScholesVanillaEngine>(bsmProcess,
+                                                                             timeSteps,
+                                                                             timeSteps - 1));
+
+    return american->NPV();
+}
+
+
+// Sensitivities with XAD
+#ifndef QLXAD_DISABLE_AAD
+
+// create tape
+using tape_type = Real::tape_type;
+tape_type tape;
+
+Real priceWithSensi(Rate riskFreeRate, const Calendar& calendar,
+                    const Date maturity, Real strike, const Date settlementDate,
+                    DayCounter dayCounter, Volatility volatility, Date todaysDate,
+                    Spread dividendYield, Option::Type type, Real underlying,
+                    const std::vector<Date>& exerciseDates, std::vector<Real>& gradient)
+{
+    // register the independent inputs
+    tape.registerInput(riskFreeRate);
+    tape.registerInput(strike);
+    tape.registerInput(volatility);
+    tape.registerInput(underlying);
+    tape.registerInput(dividendYield);
+    tape.newRecording();
+
+    Real value = priceAmerican(riskFreeRate, calendar, maturity, strike,
+                               settlementDate, dayCounter, volatility, todaysDate, dividendYield, type, underlying, exerciseDates);
+
+    // register dependent variables and roll back the adjoints
+    tape.registerOutput(value);
+    derivative(value) = 1.0;
+    tape.computeAdjoints();
+
+    // add adjoints to the gradient vector
+    gradient.push_back(derivative(riskFreeRate));
+    gradient.push_back(derivative(strike));
+    gradient.push_back(derivative(volatility));
+    gradient.push_back(derivative(underlying));
+    gradient.push_back(derivative(dividendYield));
+
+    return value;
+}
+
+#endif
+
+void printResults(Real v, const std::vector<Real> &gradient)
+{
+
+    std::cout << "\nGreeks:\n";
+    std::cout << "Rho                = " << gradient[0] << "\n";
+    std::cout << "Strike Sensitivity = " << gradient[1] << "\n";
+    std::cout << "Vega               = " << gradient[2] << "\n";
+    std::cout << "Delta              = " << gradient[3] << "\n";
+    std::cout << "Dividend Rho       = " << gradient[4] << "\n";
+
+    std::cout << std::endl;
+}
+
+int main()
+{
+    try
+    {
+        // set up dates
+        Calendar calendar = TARGET();
+        Date todaysDate(15, May, 1998);
+        Date settlementDate(17, May, 1998);
+        Settings::instance().evaluationDate() = todaysDate;
+
+        // our option
+        Option::Type type(Option::Put);
+        Real underlying = 36;
+        Real strike = 40;
+        Spread dividendYield = 0.00;
+        Rate riskFreeRate = 0.06;
+        Volatility volatility = 0.20;
+        Date maturity(17, May, 1999);
+        DayCounter dayCounter = Actual365Fixed();
+
+        std::vector<Date> exerciseDates;
+        for (Integer i = 1; i <= 4; i++)
+            exerciseDates.push_back(settlementDate + 3 * i * Months);
+
+        std::cout.precision(10);
+
+#ifdef QLXAD_DISABLE_AAD
+        std::cout << "Pricing American equity option (without sensitivities)...\n";
+        Real v = priceAmerican(riskFreeRate, calendar, maturity, strike,
+                    settlementDate, dayCounter, volatility, todaysDate,
+                    dividendYield, type, underlying, exerciseDates);
+        std::cout << "American equity option value: " << v << "\n";
+#else
+        std::vector<Real> gradient;
+        std::cout << "Pricing American equity option with sensitivities...\n";
+        Real v = priceWithSensi(riskFreeRate, calendar, maturity, strike,
+                settlementDate, dayCounter, volatility, todaysDate,
+                dividendYield, type, underlying, exerciseDates, gradient);
+        std::cout << "American equity option value: " << v << "\n";
+        printResults(v, gradient);
+#endif
+
+        return 0;
+    }
+    catch (std::exception &e)
+    {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    }
+    catch (...)
+    {
+        std::cerr << "unknown error" << std::endl;
+        return 1;
+    }
+}

--- a/Examples/AdjointAmericanEquityOption/CMakeLists.txt
+++ b/Examples/AdjointAmericanEquityOption/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(AdjointAmericanEquityOption AdjointAmericanEquityOptionXAD.cpp)
+target_link_libraries(AdjointAmericanEquityOption ql_library)
+if(QL_INSTALL_EXAMPLES)
+    install(TARGETS AdjointAmericanEquityOption RUNTIME DESTINATION  ${QL_INSTALL_EXAMPLESDIR})
+endif()

--- a/Examples/AdjointBermudanSwaption/AdjointBermudanSwaptionXAD.cpp
+++ b/Examples/AdjointBermudanSwaption/AdjointBermudanSwaptionXAD.cpp
@@ -24,6 +24,8 @@
 /*
 This example demonstrates how to use XAD to price a Bermudan Swaption with
 sensitivities.
+
+TODO: Use the implicit function theorem for calibration with AAD.
 */
 
 #include <ql/qldefines.hpp>

--- a/Examples/AdjointBermudanSwaption/AdjointBermudanSwaptionXAD.cpp
+++ b/Examples/AdjointBermudanSwaption/AdjointBermudanSwaptionXAD.cpp
@@ -1,9 +1,10 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
-/*
- Copyright (C) 2022 Xcelerit
- 
- This example is based on code by Peter Caspers.
+/*!
+ Copyright (C) 2002, 2003 Sadruddin Rejeb
+ Copyright (C) 2004 Ferdinando Ametrano
+ Copyright (C) 2005, 2006, 2007 StatPro Italia srl
+ Copyright (C) 2023 Xcelerit
 
  This file is part of QuantLib / XAD integration module.
  It is modified from QuantLib, a free-software/open-source library
@@ -20,280 +21,236 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
+/*
+This example demonstrates how to use XAD to price a Bermudan Swaption with
+sensitivities.
+*/
 
+#include <ql/qldefines.hpp>
+#if !defined(BOOST_ALL_NO_LIB) && defined(BOOST_MSVC)
+#    include <ql/auto_link.hpp>
+#endif
+#include <ql/cashflows/coupon.hpp>
+#include <ql/indexes/ibor/euribor.hpp>
 #include <ql/instruments/swaption.hpp>
-#include <ql/pricingengines/swap/discountingswapengine.hpp>
-#include <ql/pricingengines/swaption/treeswaptionengine.hpp>
-#include <ql/pricingengines/swaption/jamshidianswaptionengine.hpp>
-#include <ql/pricingengines/swaption/g2swaptionengine.hpp>
-#include <ql/pricingengines/swaption/fdhullwhiteswaptionengine.hpp>
-#include <ql/pricingengines/swaption/fdg2swaptionengine.hpp>
+#include <ql/math/optimization/levenbergmarquardt.hpp>
 #include <ql/models/shortrate/calibrationhelpers/swaptionhelper.hpp>
 #include <ql/models/shortrate/onefactormodels/blackkarasinski.hpp>
-#include <ql/math/optimization/levenbergmarquardt.hpp>
-#include <ql/indexes/ibor/euribor.hpp>
-#include <ql/cashflows/coupon.hpp>
+#include <ql/pricingengines/swap/discountingswapengine.hpp>
+#include <ql/pricingengines/swaption/fdg2swaptionengine.hpp>
+#include <ql/pricingengines/swaption/fdhullwhiteswaptionengine.hpp>
+#include <ql/pricingengines/swaption/g2swaptionengine.hpp>
+#include <ql/pricingengines/swaption/jamshidianswaptionengine.hpp>
+#include <ql/pricingengines/swaption/treeswaptionengine.hpp>
 #include <ql/quotes/simplequote.hpp>
 #include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/time/calendars/target.hpp>
 #include <ql/time/daycounters/thirty360.hpp>
 #include <ql/utilities/dataformatters.hpp>
-
-
-#include <vector>
-#include <chrono>
-#include <iostream>
 #include <iomanip>
-#include <ql/termstructures/yield/ratehelpers.hpp>
-#include <ql/termstructures/iterativebootstrap.hpp>
-#include <ql/termstructures/yield/piecewiseyieldcurve.hpp>
-#include <ql/termstructures/volatility/swaption/swaptionvolmatrix.hpp>
-#include <ql/indexes/swap/euriborswap.hpp>
-#include <ql/termstructures/volatility/swaption/sabrswaptionvolatilitycube.hpp>
-#include <ql/time/daycounters/actual360.hpp>
-#include <ql/models/shortrate/onefactormodels/gsr.hpp>
-#include <ql/pricingengines/swaption/gaussian1dswaptionengine.hpp>
-
+#include <iostream>
 
 using namespace QuantLib;
+
+// Number of swaptions to be calibrated to...
+void calibrateModel(const ext::shared_ptr<ShortRateModel>& model,
+                    const std::vector<ext::shared_ptr<BlackCalibrationHelper>>& swaptions,
+                    const std::vector<Integer>& swapLengths,
+                    const std::vector<Volatility>& swaptionVols,
+                    Size numRows,
+                    Size numCols) {
+
+    std::vector<ext::shared_ptr<CalibrationHelper>> helpers(swaptions.begin(), swaptions.end());
+    LevenbergMarquardt om;
+    model->calibrate(helpers, om, EndCriteria(400, 100, 1.0e-8, 1.0e-8, 1.0e-8));
+}
+
+Handle<YieldTermStructure> setupYields(Date settlementDate, Real flatRate) {
+    // flat yield term structure impling 1x5 swap at 5%
+    auto rate = ext::make_shared<SimpleQuote>(flatRate);
+    return Handle<YieldTermStructure>(
+        ext::make_shared<FlatForward>(settlementDate, Handle<Quote>(rate), Actual365Fixed()));
+}
+
+Real priceSwaption(const std::vector<Integer>& swapLengths,
+                   const std::vector<Volatility>& swaptionVols,
+                   Size numRows,
+                   Size numCols,
+                   Real flatRate) {
+
+    Date todaysDate(15, February, 2002);
+    Calendar calendar = TARGET();
+    Date settlementDate(19, February, 2002);
+    Settings::instance().evaluationDate() = todaysDate;
+
+    auto rhTermStructure = setupYields(settlementDate, flatRate);
+
+    // Define the ITM swap
+    Frequency fixedLegFrequency = Annual;
+    BusinessDayConvention fixedLegConvention = Unadjusted;
+    BusinessDayConvention floatingLegConvention = ModifiedFollowing;
+    DayCounter fixedLegDayCounter = Thirty360(Thirty360::European);
+    Frequency floatingLegFrequency = Semiannual;
+    Swap::Type type = Swap::Payer;
+    Rate dummyFixedRate = 0.03;
+    auto indexSixMonths = ext::make_shared<Euribor6M>(rhTermStructure);
+
+    Date startDate = calendar.advance(settlementDate, 1, Years, floatingLegConvention);
+    Date maturity = calendar.advance(startDate, 5, Years, floatingLegConvention);
+    Schedule fixedSchedule(startDate, maturity, Period(fixedLegFrequency), calendar,
+                           fixedLegConvention, fixedLegConvention, DateGeneration::Forward, false);
+    Schedule floatSchedule(startDate, maturity, Period(floatingLegFrequency), calendar,
+                           floatingLegConvention, floatingLegConvention, DateGeneration::Forward,
+                           false);
+
+    auto swap = ext::make_shared<VanillaSwap>(type, 1000.0, fixedSchedule, dummyFixedRate,
+                                              fixedLegDayCounter, floatSchedule, indexSixMonths,
+                                              0.0, indexSixMonths->dayCounter());
+    swap->setPricingEngine(ext::make_shared<DiscountingSwapEngine>(rhTermStructure));
+    Rate fixedITMRate = swap->fairRate() * 0.8;
+
+    auto itmSwap = ext::make_shared<VanillaSwap>(type, 1000.0, fixedSchedule, fixedITMRate,
+                                                 fixedLegDayCounter, floatSchedule, indexSixMonths,
+                                                 0.0, indexSixMonths->dayCounter());
+
+    // defining the swaptions to be used in model calibration
+    std::vector<Period> swaptionMaturities = {1 * Years, 2 * Years, 3 * Years, 4 * Years,
+                                              5 * Years};
+
+    std::vector<ext::shared_ptr<BlackCalibrationHelper>> swaptions;
+
+    // List of times that have to be included in the timegrid
+    std::list<Time> times;
+
+    Size i;
+    for (i = 0; i < numRows; i++) {
+        Size j = numCols - i - 1; // 1x5, 2x4, 3x3, 4x2, 5x1
+        Size k = i * numCols + j;
+        ext::shared_ptr<Quote> vol(new SimpleQuote(swaptionVols[k]));
+        swaptions.push_back(ext::make_shared<SwaptionHelper>(
+            swaptionMaturities[i], Period(swapLengths[j], Years), Handle<Quote>(vol),
+            indexSixMonths, indexSixMonths->tenor(), indexSixMonths->dayCounter(),
+            indexSixMonths->dayCounter(), rhTermStructure));
+        swaptions.back()->addTimesTo(times);
+    }
+
+    // Building time-grid
+    TimeGrid grid(times.begin(), times.end(), 30);
+
+    // defining the models
+    auto modelHW = ext::make_shared<HullWhite>(rhTermStructure);
+
+
+    // model calibrations
+    for (i = 0; i < swaptions.size(); i++)
+        swaptions[i]->setPricingEngine(ext::make_shared<JamshidianSwaptionEngine>(modelHW));
+
+    calibrateModel(modelHW, swaptions, swapLengths, swaptionVols, numRows, numCols);
+
+
+    std::vector<Date> bermudanDates;
+    const auto& leg = swap->fixedLeg();
+    for (i = 0; i < leg.size(); i++) {
+        auto coupon = ext::dynamic_pointer_cast<Coupon>(leg[i]);
+        bermudanDates.push_back(coupon->accrualStartDate());
+    }
+
+    auto bermudanExercise = ext::make_shared<BermudanExercise>(bermudanDates);
+    Swaption itmBermudanSwaption(itmSwap, bermudanExercise);
+
+    // Do the pricing
+    // itmBermudanSwaption.setPricingEngine(ext::make_shared<TreeSwaptionEngine>(modelHW, 50));
+    itmBermudanSwaption.setPricingEngine(ext::make_shared<FdHullWhiteSwaptionEngine>(modelHW));
+    return itmBermudanSwaption.NPV();
+}
+
+
+// Sensitivities with XAD
+#ifndef QLXAD_DISABLE_AAD
 
 // create tape
 using tape_type = Real::tape_type;
 tape_type tape;
 
-Handle<YieldTermStructure> bootstrapYields(const Date& refDate) {
-	Handle<Quote> swapQuote(ext::make_shared<SimpleQuote>(0.03));
-	auto euribor6mBt = ext::make_shared<Euribor>(6 * Months);
-	std::vector<ext::shared_ptr<RateHelper>> helpers;
-	for (Size i = 1; i <= 30; ++i) {
-		helpers.push_back(
-			ext::make_shared<SwapRateHelper>(
-				swapQuote, i * Years, TARGET(), Annual, ModifiedFollowing,
-				Thirty360(Thirty360::European), euribor6mBt)
-		);
-	}
-	auto yts6m =
-		ext::make_shared<PiecewiseYieldCurve<ZeroYield, Linear,
-		IterativeBootstrap> >(
-			refDate, helpers, Actual365Fixed());
+Real priceWithSensi(const std::vector<Integer>& swapLengths,
+                    const std::vector<Volatility>& swaptionVols,
+                    Size numRows,
+                    Size numCols,
+                    Real flatRate,
+                    std::vector<Real>& gradient) {
+    // register the independent inputs
+    auto swaptionVols_t = swaptionVols;
+    tape.registerInputs(swaptionVols_t);
+    tape.newRecording();
 
-	Handle<YieldTermStructure> yts6m_h(yts6m);
+    Real v = priceSwaption(swapLengths, swaptionVols_t, numRows, numCols, flatRate);
 
-	yts6m_h->enableExtrapolation();
+    // register dependent output, set adjoint, and roll back to input adjoints
+    tape.registerOutput(v);
+    derivative(v) = 1.0;
+    tape.computeAdjoints();
 
-	return yts6m_h;
+    // store adjoints in gradient vector
+    for (auto& vol : swaptionVols_t) {
+        gradient.push_back(derivative(vol));
+    }
+
+    return v;
 }
 
-void prepareTenors(std::vector<Period>& optionTenors, std::vector<Period>& swapTenors)
-{
-	optionTenors = {
-			3 * Months, 6 * Months, 1 * Years, 2 * Years, 3 * Years,
-			4 * Years, 5 * Years, 6 * Years, 7 * Years, 8 * Years, 9 * Years,
-			10 * Years, 12 * Years, 15 * Years, 20 * Years, 30 * Years
-	};
-	swapTenors = {
-		1 * Years, 2 * Years, 3 * Years, 4 * Years, 5 * Years,
-		6 * Years, 7 * Years, 8 * Years, 9 * Years, 10 * Years, 15 * Years,
-		20 * Years, 25 * Years, 30 * Years
-	};
+#endif
+
+
+void printResults(Real value, const std::vector<Real>& gradient) {
+    std::cout.precision(6);
+    std::cout << std::fixed;
+    std::cout.imbue(std::locale(""));
+
+    std::cout << "Price = " << value << std::endl;
+    std::cout << "Vegas:\n";
+    for (std::size_t i = 0; i < gradient.size(); ++i)
+        std::cout << "Vega #" << i << " = " << gradient[i] << "\n";
+
+    std::cout << std::endl;
 }
 
-Handle<SwaptionVolatilityStructure> swaptionVolatilities(const std::vector<Period>& optionTenors, const std::vector<Period>& swapTenors) {
+int main(int, char*[]) {
 
-	// atm vol structure
-	Matrix atmVols(optionTenors.size(), swapTenors.size(), 0.20);
-	ext::shared_ptr<SwaptionVolatilityMatrix> swatm =
-		ext::make_shared<SwaptionVolatilityMatrix>(
-			TARGET(), ModifiedFollowing, optionTenors, swapTenors, atmVols,
-			Actual365Fixed());
-	Handle<SwaptionVolatilityStructure> swatm_h(swatm);
+    try {
 
-	return swatm_h;
-}
+        std::cout << std::endl;
 
-void getSabrParams(std::vector<Real>& strikeSpreads,
-	std::vector<std::vector<Handle<Quote> > >& volSpreads,
-	std::vector<std::vector<Handle<Quote> > >& sabrParams,
-	std::vector<bool>& paramFixed,
-	Size NoptTenors, Size NswapTenors) {
+        // rate
+        Real flatRate = 0.04875825;
 
-	// we assume we know the SABR parameters
-	strikeSpreads.push_back(.0);
+        // volatilities
+        Size numRows = 5;
+        Size numCols = 5;
 
-	for (Size i = 0; i < NoptTenors * NswapTenors; ++i) {
-		// spreaded vols
-		std::vector<Handle<Quote>> volTmp(1, Handle<Quote>(ext::make_shared<SimpleQuote>(0.0)));
-		volSpreads.push_back(std::move(volTmp));
-		// sabr parameters
-		std::vector<Handle<Quote>> sabrTmp = {
-			Handle<Quote>(ext::make_shared<SimpleQuote>(0.03)), // alpha
-			Handle<Quote>(ext::make_shared<SimpleQuote>(0.60)), // beta
-			Handle<Quote>(ext::make_shared<SimpleQuote>(0.12)), // nu
-			Handle<Quote>(ext::make_shared<SimpleQuote>(0.30)), // rho
-		};
-		sabrParams.push_back(std::move(sabrTmp));
-	}
-	paramFixed = { true, true, true, true };
-}
+        std::vector<Integer> swapLengths = {1, 2, 3, 4, 5};
+        std::vector<Volatility> swaptionVols = {
+            0.1490, 0.1340, 0.1228, 0.1189, 0.1148, 0.1290, 0.1201, 0.1146, 0.1108,
+            0.1040, 0.1149, 0.1112, 0.1070, 0.1010, 0.0957, 0.1047, 0.1021, 0.0980,
+            0.0951, 0.1270, 0.1000, 0.0950, 0.0900, 0.1230, 0.1160};
 
-Real priceSwaption(std::vector<Real>& inputVol, const Schedule& fixedSchedule,
-	const Schedule& floatingSchedule, Real strike, const std::vector<Date>& exerciseDates,
-	ext::shared_ptr<Euribor> euribor6m, Handle<YieldTermStructure> yts6m_h, Date refDate) {
+#ifdef QLXAD_DISABLE_AAD
+        std::cout << "Pricing Bermudan swaption without sensitivities...\n";
+        Real price = priceSwaption(swapLengths, swaptionVols, numRows, numCols, flatRate);
+        std::cout << "Price = " << price << std::endl;
+#else
+        std::cout << "Pricing Bermudan swaption with sensitivities...\n";
+        std::vector<Real> gradient;
+        Real price =
+            priceWithSensi(swapLengths, swaptionVols, numRows, numCols, flatRate, gradient);
+        printResults(price, gradient);
+#endif
 
-	auto underlying =
-		ext::make_shared<VanillaSwap>(
-			VanillaSwap::Payer, 1.0, fixedSchedule, strike,
-			Thirty360(Thirty360::European), floatingSchedule, euribor6m, 0.0, Actual360());
-	auto exercise = ext::make_shared<BermudanExercise>(exerciseDates, false);
-
-	// the GSR model
-	std::vector<Date> stepDates(exerciseDates.begin(), exerciseDates.end() - 1);
-	std::vector<Real> sigmas(stepDates.size() + 1, 0.01);
-	Real reversion = 0.01;
-	auto gsr = ext::make_shared<Gsr>(yts6m_h, stepDates, sigmas, reversion);
-
-
-	std::vector<ext::shared_ptr<BlackCalibrationHelper>> basket;
-	auto swaptionEngine = ext::make_shared<Gaussian1dSwaptionEngine>(gsr, 32, 5.0);
-
-	for (Size i = 1; i < 10; ++i) {
-		Period swapLength = (10 - i) * Years;
-		Handle<Quote> vol_q(ext::make_shared<SimpleQuote>(inputVol[i - 1]));
-		auto tmp = ext::make_shared<SwaptionHelper>(
-			exerciseDates[i - 1], swapLength, vol_q, euribor6m,
-			1 * Years, Thirty360(Thirty360::European), Actual360(), yts6m_h,
-			SwaptionHelper::RelativePriceError, strike, 1.0);
-		tmp->setPricingEngine(swaptionEngine);
-		basket.push_back(tmp);
-	}
-
-	// calibrate the model
-	LevenbergMarquardt method;
-	EndCriteria ec(1000, 10, 1E-8, 1E-8, 1E-8);
-
-	gsr->calibrateVolatilitiesIterative(basket, method, ec);
-	auto volatility = gsr->volatility();
-
-	auto swaption = ext::make_shared<Swaption>(underlying, exercise);
-	swaption->setPricingEngine(swaptionEngine);
-	return swaption->NPV();
-}
-
-Real priceWithSensi(std::vector<Real>& inputVol, const Schedule& fixedSchedule,
-	const Schedule& floatingSchedule, Real strike, const std::vector<Date>& exerciseDates,
-	ext::shared_ptr<Euribor> euribor6m, Handle<YieldTermStructure> yts6m_h, Date refDate,
-	std::vector<Real>& gradient) {
-
-	tape.clearAll();
-	tape.registerInputs(inputVol);
-	tape.newRecording();
-
-	Real value = priceSwaption(inputVol, fixedSchedule, floatingSchedule, strike, exerciseDates, euribor6m, yts6m_h, refDate);
-
-	// get the vegas
-	tape.registerOutput(value);
-	derivative(value) = 1.0;
-	tape.computeAdjoints();
-
-	gradient.resize(inputVol.size());
-	std::transform(inputVol.begin(), inputVol.end(), gradient.begin(), [](const Real& vol) { return derivative(vol);  });
-
-	return value;
-}
-
-void printResults(Real v, const std::vector<Real>& gradient) {
-	
-	std::cout.precision(6);
-	std::cout << std::fixed;
-	std::cout.imbue(std::locale(""));
-
-	std::cout << "\nSensitivities w.r.t. volatilities:\n";
-	for (std::size_t i = 0; i < gradient.size(); ++i)
-		std::cout << "Vega #" << i << " = " << gradient[i] << "\n";
-
-	std::cout << std::endl;
-}
-
-int main() {
-
-	try {
-		Date refDate(13, April, 2015);
-		Settings::instance().evaluationDate() = refDate;
-
-		Handle<YieldTermStructure> yts6m_h = bootstrapYields(refDate);
-		auto euribor6m = ext::make_shared<Euribor>(6 * Months, yts6m_h);
-		std::vector<Period> optionTenors, swapTenors;
-		prepareTenors(optionTenors, swapTenors);
-		Handle<SwaptionVolatilityStructure> swatm_h = swaptionVolatilities(optionTenors, swapTenors);
-		std::vector<Real> strikeSpreads;
-		std::vector<std::vector<Handle<Quote> > > volSpreads,
-			sabrParams;
-		std::vector<bool> paramFixed;
-		getSabrParams(strikeSpreads, volSpreads, sabrParams, paramFixed, optionTenors.size(), swapTenors.size());
-
-		auto indexBase = ext::make_shared<EuriborSwapIsdaFixA>(30 * Years, yts6m_h);
-		auto indexBaseShort = ext::make_shared<EuriborSwapIsdaFixA>(2 * Years, yts6m_h);
-		auto swvol = ext::make_shared<SabrSwaptionVolatilityCube>(
-			swatm_h, optionTenors, swapTenors, strikeSpreads, volSpreads,
-			indexBase, indexBaseShort, true, sabrParams, paramFixed, true,
-			boost::shared_ptr<EndCriteria>(), 100.0);
-		Handle<SwaptionVolatilityStructure> swvol_h(swvol);
-
-		// Setup the Bermudan Swaption
-		Date effectiveDate = TARGET().advance(refDate, 2 * Days);
-		Date maturityDate = TARGET().advance(effectiveDate, 10 * Years);
-		Schedule fixedSchedule(effectiveDate, maturityDate, 1 * Years, TARGET(),
-			ModifiedFollowing, ModifiedFollowing,
-			DateGeneration::Forward, false);
-		Schedule floatingSchedule(effectiveDate, maturityDate, 6 * Months,
-			TARGET(), ModifiedFollowing,
-			ModifiedFollowing, DateGeneration::Forward,
-			false);
-		Real strike = 0.03;
-
-		std::vector<Date> exerciseDates;
-		for (Size i = 1; i < 10; ++i) {
-			exerciseDates.push_back(TARGET().advance(fixedSchedule[i], -2 * Days));
-		}
-
-		// calibration basket
-		std::vector<Real> inputVol(9, 0.0);
-		for (Size i = 1; i < 10; ++i) {
-			Period swapLength = (10 - i) * Years;
-			inputVol[i - 1] = swvol->volatility(exerciseDates[i - 1], swapLength, strike);
-		}
-
-		// pricing without AAD
-		std::cout << "Pricing Bermudan swaption...\n";
-		auto start = std::chrono::high_resolution_clock::now();
-		Real v = priceSwaption(inputVol, fixedSchedule, floatingSchedule, strike, exerciseDates, euribor6m, yts6m_h, refDate);
-		auto end = std::chrono::high_resolution_clock::now();
-		auto time_plain = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count()) * 1e-3;
-		std::cout << "Swaption Value: " << v << "\n";
-
-		// pricing with AAD
-		std::vector<Real> gradient;
-		std::cout << "Pricing Bermudan swaption with sensitivities...\n";
-		start = std::chrono::high_resolution_clock::now();
-		Real v2 = priceWithSensi(inputVol, fixedSchedule, floatingSchedule, strike, exerciseDates, euribor6m, yts6m_h, refDate, gradient);
-		end = std::chrono::high_resolution_clock::now();
-		auto time_sensi = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count()) * 1e-3;
-		std::cout << "Swaption Value: " << v2 << "\n";
-
-		printResults(v2, gradient);
-
-		std::cout << "Plain time : " << time_plain << "ms\n"
-			<< "Sensi time : " << time_sensi << "ms\n"
-			<< "Factor     : " << time_sensi / time_plain << "x\n";
-
-		return 0;
-	}
-	catch (std::exception& e) {
-		std::cerr << e.what() << std::endl;
-		return 1;
-	}
-	catch (...) {
-		std::cerr << "unknown error" << std::endl;
-		return 1;
-	}
+        return 0;
+    } catch (std::exception& e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    } catch (...) {
+        std::cerr << "unknown error" << std::endl;
+        return 1;
+    }
 }

--- a/Examples/AdjointCDS/AdjointCdsXAD.cpp
+++ b/Examples/AdjointCDS/AdjointCdsXAD.cpp
@@ -1,0 +1,201 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*!
+ Copyright (C) 2008 Jose Aparicio
+ Copyright (C) 2014 Peter Caspers
+ Copyright (C) 2023 Xcelerit
+
+ This file is part of QuantLib / XAD integration module.
+ It is modified from QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*
+This example shows how to use XAD to price a CDS with sensitivities.
+*/
+
+#include <ql/qldefines.hpp>
+#if !defined(BOOST_ALL_NO_LIB) && defined(BOOST_MSVC)
+#    include <ql/auto_link.hpp>
+#endif
+#include <ql/exercise.hpp>
+#include <ql/math/interpolations/backwardflatinterpolation.hpp>
+#include <ql/pricingengines/credit/midpointcdsengine.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/termstructures/credit/defaultprobabilityhelpers.hpp>
+#include <ql/termstructures/credit/flathazardrate.hpp>
+#include <ql/termstructures/credit/interpolatedhazardratecurve.hpp>
+#include <ql/termstructures/credit/piecewisedefaultcurve.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/termstructures/yield/zerocurve.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+using namespace std;
+using namespace QuantLib;
+
+
+Real priceCDS(const std::vector<Real>& hazardRates,
+              const std::vector<Date>& dates,
+              const std::vector<Real>& riskFreeRates,
+              Date issueDate,
+              Date maturity,
+              Real recoveryRate,
+              Real fixedRate,
+              Calendar& calendar,
+              const DayCounter& dayCount,
+              Real notional) {
+    RelinkableHandle<DefaultProbabilityTermStructure> probabilityCurve;
+    auto hazardCurve =
+        ext::make_shared<InterpolatedHazardRateCurve<BackwardFlat>>(dates, hazardRates, dayCount);
+    probabilityCurve.linkTo(hazardCurve);
+
+    RelinkableHandle<YieldTermStructure> discountCurve;
+
+    discountCurve.linkTo(ext::make_shared<ZeroCurve>(dates, riskFreeRates, dayCount));
+
+    Frequency frequency = Semiannual;
+    BusinessDayConvention convention = ModifiedFollowing;
+
+    Schedule schedule(issueDate, maturity, Period(frequency), calendar, convention, convention,
+                      DateGeneration::Forward, false);
+
+    auto cds = ext::make_shared<CreditDefaultSwap>(Protection::Seller, notional, fixedRate,
+                                                   schedule, convention, dayCount, true, true);
+    cds->setPricingEngine(
+        ext::make_shared<MidPointCdsEngine>(probabilityCurve, recoveryRate, discountCurve));
+    return cds->NPV();
+}
+
+// Sensitivities with XAD
+#ifndef QLXAD_DISABLE_AAD
+
+// create tape
+using tape_type = Real::tape_type;
+tape_type tape;
+
+
+Real priceWithSensi(const std::vector<Real>& hazardRates,
+                    std::vector<Date>& dates,
+                    const std::vector<Real>& riskFreeRate,
+                    Date issueDate,
+                    Date& maturity,
+                    Real recoveryRate,
+                    Real fixedRate,
+                    Calendar& calendar,
+                    DayCounter& dayCount,
+                    Real notional,
+                    std::vector<Real>& gradient) {
+    // register the independent inputs
+    auto riskFreeRates_t = riskFreeRate;
+    auto hazardRates_t = hazardRates;
+    tape.registerInputs(riskFreeRates_t);
+    tape.registerInputs(hazardRates_t);
+    tape.registerInput(recoveryRate);
+    tape.registerInput(fixedRate);
+    tape.registerInput(notional);
+    tape.newRecording();
+
+    Real value = priceCDS(hazardRates_t, dates, riskFreeRates_t, issueDate, maturity, recoveryRate,
+                          fixedRate, calendar, dayCount, notional);
+
+    // register dependent variables and roll back the adjoints
+    tape.registerOutput(value);
+    derivative(value) = 1.0;
+    tape.computeAdjoints();
+
+    for (auto& r : riskFreeRates_t) {
+        gradient.push_back(derivative(r));
+    }
+    for (auto& a : hazardRates_t) {
+        gradient.push_back(derivative(a));
+    }
+    gradient.push_back(derivative(recoveryRate));
+    gradient.push_back(derivative(fixedRate));
+    gradient.push_back(derivative(notional));
+
+    return value;
+}
+
+#endif
+
+void printResults(Real v, const std::vector<Real>& gradient) {
+    std::cout << "CDS value           = " << v << "\n";
+    std::cout << "Rhos                = "
+              << "[";
+    for (int i = 0; i < 9; ++i)
+        std::cout << gradient[i] << ", ";
+    std::cout << "]\n";
+    std::cout << "Hazard rate sensitivities = [";
+    for (int i = 9; i < 17; ++i)
+        std::cout << gradient[i] << ", ";
+    std::cout << "]\n";
+    std::cout << "Recovery rate sensitivity = " << gradient[17] << "\n";
+    std::cout << "Fixed rate sensitivity    = " << gradient[18] << "\n";
+    std::cout << "Notional sensitivity      = " << gradient[19] << "\n";
+}
+
+int main() {
+    try {
+        DayCounter dayCount = Actual360();
+        // Initialize curves
+        Settings::instance().evaluationDate() = Date(9, June, 2006);
+        Date today = Settings::instance().evaluationDate();
+        Calendar calendar = TARGET();
+
+        Date issueDate = calendar.advance(today, -1, Years);
+        Date maturity = calendar.advance(issueDate, 2, Years);
+
+
+        // Build the CDS
+        Rate fixedRate = 0.0120;
+        Real notional = 10000.0;
+        Real recoveryRate = 0.4;
+        std::vector<Integer> tn = {13, 41, 75, 165, 256, 345, 524, 703};
+        std::vector<Rate> riskFreeRate = {0.0357, 0.0357, 0.0349, 0.0341, 0.0355,
+                                          0.0359, 0.0368, 0.0386, 0.0401};
+        std::vector<Rate> hazardRates = {0.0,     0.00234, 0.042,   0.0064, 0.00734,
+                                         0.00934, 0.012,   0.01234, 0.01634};
+
+        std::vector<Date> dates;
+        dates.push_back(today);
+        Size i;
+        for (i = 0; i < tn.size(); ++i) {
+            dates.push_back(today + tn[i]);
+        }
+
+#ifdef QLXAD_DISABLE_AAD
+        std::cout << "Pricing a CDS without sensitivities...\n";
+        Real v = priceCDS(hazardRates, dates, riskFreeRate, issueDate, maturity, recoveryRate,
+                          fixedRate, calendar, dayCount, notional);
+        std::cout << "CDS value: " << v << "\n";
+#else
+        std::vector<Real> gradient;
+        std::cout << "Pricing a CDS with sensitivities...\n";
+        Real v = priceWithSensi(hazardRates, dates, riskFreeRate, issueDate, maturity,
+                                recoveryRate, fixedRate, calendar, dayCount, notional, gradient);
+        printResults(v, gradient);
+#endif
+
+        return 0;
+    } catch (std::exception& e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    } catch (...) {
+        std::cerr << "unknown error" << std::endl;
+        return 1;
+    }
+}

--- a/Examples/AdjointCDS/CMakeLists.txt
+++ b/Examples/AdjointCDS/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(AdjointCDS AdjointCdsXAD.cpp)
+target_link_libraries(AdjointCDS ql_library)
+if(QL_INSTALL_EXAMPLES)
+    install(TARGETS AdjointCDS RUNTIME DESTINATION  ${QL_INSTALL_EXAMPLESDIR})
+endif()

--- a/Examples/AdjointEuropeanEquityOption/AdjointEuropeanEquityOptionXAD.cpp
+++ b/Examples/AdjointEuropeanEquityOption/AdjointEuropeanEquityOptionXAD.cpp
@@ -206,7 +206,7 @@ Real priceWithSensi(const std::vector<Date>& dates,
     Real eps = 1e-5;
     sensiOutput.rhos.clear();
     sensiOutput.rhos.reserve(t_rates.size());
-    for (int i = 0; i < t_rates.size(); ++i) {
+    for (Size i = 0; i < t_rates.size(); ++i) {
         t_rates[i] += eps;
         Real v1 =
             priceEuropean(dates, t_rates, t_vols, calendar, maturity, t_strikes, settlementDate,
@@ -217,7 +217,7 @@ Real priceWithSensi(const std::vector<Date>& dates,
 
     sensiOutput.vegas.clear();
     sensiOutput.vegas.reserve(t_vols.size());
-    for (int i = 0; i < t_vols.size(); ++i) {
+    for (Size i = 0; i < t_vols.size(); ++i) {
         t_vols[i] += eps;
         Real v1 =
             priceEuropean(dates, t_rates, t_vols, calendar, maturity, t_strikes, settlementDate,
@@ -228,7 +228,7 @@ Real priceWithSensi(const std::vector<Date>& dates,
 
     sensiOutput.strikeSensitivities.clear();
     sensiOutput.strikeSensitivities.reserve(t_strikes.size());
-    for (int i = 0; i < t_strikes.size(); ++i) {
+    for (Size i = 0; i < t_strikes.size(); ++i) {
         t_strikes[i] += eps;
         Real v1 =
             priceEuropean(dates, t_rates, t_vols, calendar, maturity, t_strikes, settlementDate,
@@ -240,7 +240,7 @@ Real priceWithSensi(const std::vector<Date>& dates,
     auto t_underlyings = underlyings;
     sensiOutput.deltas.clear();
     sensiOutput.deltas.reserve(underlyings.size());
-    for (int i = 0; i < t_underlyings.size(); ++i) {
+    for (Size i = 0; i < t_underlyings.size(); ++i) {
         t_underlyings[i] += eps;
         Real v1 =
             priceEuropean(dates, t_rates, t_vols, calendar, maturity, t_strikes, settlementDate,

--- a/Examples/AdjointEuropeanEquityOption/AdjointEuropeanEquityOptionXAD.cpp
+++ b/Examples/AdjointEuropeanEquityOption/AdjointEuropeanEquityOptionXAD.cpp
@@ -1,0 +1,371 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2005, 2006, 2007, 2009 StatPro Italia srl
+ Copyright (C) 2023 Xcelerit
+
+ This file is part of QuantLib / XAD integration module.
+ It is modified from QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*
+This example shows how to price a portfolio of European equity options with
+sensitivities computed via XAD (or bumping if QLXAD_DISABLE_AAD is ON).
+It measures performance and reports the times.
+
+This sample is used to validate XAD performance with an analytic engine.
+*/
+
+#include <ql/qldefines.hpp>
+#if !defined(BOOST_ALL_NO_LIB) && defined(BOOST_MSVC)
+#    include <ql/auto_link.hpp>
+#endif
+#include <ql/exercise.hpp>
+#include <ql/instruments/vanillaoption.hpp>
+#include <ql/pricingengines/vanilla/analyticeuropeanengine.hpp>
+#include <ql/processes/blackscholesprocess.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/termstructures/volatility/equityfx/blackconstantvol.hpp>
+#include <ql/termstructures/volatility/equityfx/blackvariancecurve.hpp>
+#include <ql/termstructures/volatility/equityfx/blackvoltermstructure.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/termstructures/yield/zerocurve.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+using namespace QuantLib;
+
+// to record all sensitivities of the portfolio
+struct OptionSensitivities {
+    std::vector<Real> rhos;
+    std::vector<Real> strikeSensitivities;
+    std::vector<Real> deltas;
+    std::vector<Real> vegas;
+    Real dividendRho;
+};
+
+Real priceEuropean(const std::vector<Date>& dates,
+                   const std::vector<Rate>& rates,
+                   const std::vector<Real>& vols,
+                   const Calendar& calendar,
+                   const Date maturity,
+                   const std::vector<Real>& strikes,
+                   const Date settlementDate,
+                   DayCounter& dayCounter,
+                   Date todaysDate,
+                   Spread dividendYield,
+                   Option::Type type,
+                   const std::vector<Real>& underlyings) {
+
+    auto europeanExercise = ext::make_shared<EuropeanExercise>(maturity);
+
+    // setup the yield/dividend/vol curves
+    Handle<YieldTermStructure> termStructure(ext::make_shared<ZeroCurve>(dates, rates, dayCounter));
+    Handle<YieldTermStructure> flatDividendTS(
+        ext::make_shared<FlatForward>(settlementDate, dividendYield, dayCounter));
+    // cut first date (settlement date) for vol curve
+    auto dvol = std::vector<Date>(dates.begin() + 1, dates.end());
+    Handle<BlackVolTermStructure> volTS(
+        ext::make_shared<BlackVarianceCurve>(settlementDate, dvol, vols, dayCounter));
+
+    Real value = 0.0;
+    // portfolio with several underlying values
+    for (auto& underlying : underlyings) {
+        Handle<Quote> underlyingH(ext::make_shared<SimpleQuote>(underlying));
+        auto bsmProcess = ext::make_shared<BlackScholesMertonProcess>(underlyingH, flatDividendTS,
+                                                                      termStructure, volTS);
+        auto engine = ext::make_shared<AnalyticEuropeanEngine>(bsmProcess);
+
+        // and options with several strikes for each underlying value
+        for (auto& strike : strikes) {
+            auto payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
+
+            // options
+            auto european = ext::make_shared<VanillaOption>(payoff, europeanExercise);
+            // computing the option price with the analytic Black-Scholes formulae
+            european->setPricingEngine(engine);
+
+            value += european->NPV();
+        }
+    }
+    return value;
+}
+
+// price with XAD sensitivities
+#ifndef QLXAD_DISABLE_AAD
+
+// create tape
+using tape_type = Real::tape_type;
+tape_type tape;
+
+Real priceWithSensi(const std::vector<Date>& dates,
+                    const std::vector<Rate>& rates,
+                    const std::vector<Real>& vols,
+                    const Calendar& calendar,
+                    const Date& maturity,
+                    const std::vector<Real>& strikes,
+                    const Date settlementDate,
+                    DayCounter& dayCounter,
+                    Date todaysDate,
+                    Spread dividendYield,
+                    Option::Type type,
+                    const std::vector<Real>& underlyings,
+                    OptionSensitivities& sensiOutput) {
+    // to enable repeated runs, we clear the tape first
+    tape.clearAll();
+
+    // copy inputs and register them on the tape
+    auto t_rates = rates;
+    auto t_vols = vols;
+    auto t_strikes = strikes;
+    auto t_underlyings = underlyings;
+    tape.registerInputs(t_rates);
+    tape.registerInputs(t_vols);
+    tape.registerInputs(t_strikes);
+    tape.registerInputs(t_underlyings);
+    tape.registerInput(dividendYield);
+    tape.newRecording();
+
+    // price
+    Real value =
+        priceEuropean(dates, t_rates, t_vols, calendar, maturity, t_strikes, settlementDate,
+                      dayCounter, todaysDate, dividendYield, type, t_underlyings);
+
+    // register output, set adjoint, and roll back the tape to the inputs
+    tape.registerOutput(value);
+    derivative(value) = 1.0;
+    tape.computeAdjoints();
+
+    // obtain the sensitivities and store them in the result struct
+    sensiOutput.rhos.clear();
+    sensiOutput.rhos.reserve(t_rates.size());
+    for (int i = 0; i < t_rates.size(); ++i) {
+        sensiOutput.rhos.push_back(derivative(t_rates[i]));
+    }
+    sensiOutput.vegas.clear();
+    sensiOutput.vegas.reserve(t_vols.size());
+    for (int i = 0; i < t_vols.size(); ++i) {
+        sensiOutput.vegas.push_back(derivative(t_vols[i]));
+    }
+    sensiOutput.strikeSensitivities.clear();
+    sensiOutput.strikeSensitivities.reserve(t_strikes.size());
+    for (int i = 0; i < t_strikes.size(); ++i) {
+        sensiOutput.strikeSensitivities.push_back(derivative(t_strikes[i]));
+    }
+    sensiOutput.deltas.clear();
+    sensiOutput.deltas.reserve(t_underlyings.size());
+    for (int i = 0; i < t_underlyings.size(); ++i) {
+        sensiOutput.deltas.push_back(derivative(t_underlyings[i]));
+    }
+    sensiOutput.dividendRho = derivative(dividendYield);
+
+    return value;
+}
+
+#else // pricing with bumping, as we don't have XAD available here
+
+Real priceWithSensi(const std::vector<Date>& dates,
+                    const std::vector<Rate>& rates,
+                    const std::vector<Real>& vols,
+                    const Calendar& calendar,
+                    const Date& maturity,
+                    const std::vector<Real>& strikes,
+                    const Date settlementDate,
+                    DayCounter& dayCounter,
+                    Date todaysDate,
+                    Spread dividendYield,
+                    Option::Type type,
+                    const std::vector<Real>& underlyings,
+                    OptionSensitivities& sensiOutput) {
+
+    // copy inputs for bumping
+    auto t_rates = rates;
+    auto t_vols = vols;
+    auto t_strikes = strikes;
+
+    Real value =
+        priceEuropean(dates, t_rates, t_vols, calendar, maturity, t_strikes, settlementDate,
+                      dayCounter, todaysDate, dividendYield, type, underlyings);
+
+    // bump each input independently and re-run the pricer to see its impact
+    Real eps = 1e-5;
+    sensiOutput.rhos.clear();
+    sensiOutput.rhos.reserve(t_rates.size());
+    for (int i = 0; i < t_rates.size(); ++i) {
+        t_rates[i] += eps;
+        Real v1 =
+            priceEuropean(dates, t_rates, t_vols, calendar, maturity, t_strikes, settlementDate,
+                          dayCounter, todaysDate, dividendYield, type, underlyings);
+        sensiOutput.rhos.push_back((v1 - value) / eps);
+        t_rates[i] -= eps;
+    }
+
+    sensiOutput.vegas.clear();
+    sensiOutput.vegas.reserve(t_vols.size());
+    for (int i = 0; i < t_vols.size(); ++i) {
+        t_vols[i] += eps;
+        Real v1 =
+            priceEuropean(dates, t_rates, t_vols, calendar, maturity, t_strikes, settlementDate,
+                          dayCounter, todaysDate, dividendYield, type, underlyings);
+        sensiOutput.vegas.push_back((v1 - value) / eps);
+        t_vols[i] -= eps;
+    }
+
+    sensiOutput.strikeSensitivities.clear();
+    sensiOutput.strikeSensitivities.reserve(t_strikes.size());
+    for (int i = 0; i < t_strikes.size(); ++i) {
+        t_strikes[i] += eps;
+        Real v1 =
+            priceEuropean(dates, t_rates, t_vols, calendar, maturity, t_strikes, settlementDate,
+                          dayCounter, todaysDate, dividendYield, type, underlyings);
+        sensiOutput.strikeSensitivities.push_back((v1 - value) / eps);
+        t_strikes[i] -= eps;
+    }
+
+    auto t_underlyings = underlyings;
+    sensiOutput.deltas.clear();
+    sensiOutput.deltas.reserve(underlyings.size());
+    for (int i = 0; i < t_underlyings.size(); ++i) {
+        t_underlyings[i] += eps;
+        Real v1 =
+            priceEuropean(dates, t_rates, t_vols, calendar, maturity, t_strikes, settlementDate,
+                          dayCounter, todaysDate, dividendYield, type, t_underlyings);
+        sensiOutput.deltas.push_back((v1 - value) / eps);
+        t_underlyings[i] -= eps;
+    }
+
+    Real v1 = priceEuropean(dates, t_rates, t_vols, calendar, maturity, t_strikes, settlementDate,
+                            dayCounter, todaysDate, dividendYield + eps, type, underlyings);
+    sensiOutput.dividendRho = (v1 - value) / eps;
+
+    return value;
+}
+
+#endif
+
+void printResults(Real v, const OptionSensitivities& sensiOutput) {
+    std::cout << "\nGreeks:\n";
+    std::cout << "Rhos                  = [";
+    for (auto& rho : sensiOutput.rhos) {
+        std::cout << rho << ", ";
+    }
+    std::cout << "]\n";
+    std::cout << "Strike Sensitivities = [";
+    for (auto& s : sensiOutput.strikeSensitivities) {
+        std::cout << s << ", ";
+    }
+    std::cout << "]\n";
+    std::cout << "Vegas               = [";
+    for (auto& vega : sensiOutput.vegas) {
+        std::cout << vega << ", ";
+    }
+    std::cout << "]\n";
+    std::cout << "Deltas               = [";
+    for (auto& delta : sensiOutput.deltas) {
+        std::cout << delta << ", ";
+    }
+    std::cout << "]\n";
+    std::cout << "Dividend Rho         = " << sensiOutput.dividendRho << "\n";
+
+    std::cout << std::endl;
+}
+
+int main() {
+    try {
+        // set up dates
+        Calendar calendar = TARGET();
+        Date todaysDate(15, May, 1998);
+        Date settlementDate(17, May, 1998);
+        Settings::instance().evaluationDate() = todaysDate;
+
+        // curves
+        std::vector<Integer> t = {13, 41, 75, 165, 256, 345, 524, 703};
+        std::vector<Rate> r = {0.0357, 0.0349, 0.0341, 0.0355, 0.0359, 0.0368, 0.0386, 0.0401};
+        std::vector<Volatility> vols = {0.20, 0.18, 0.178, 0.183, 0.192, 0.203, 0.215, 0.208};
+
+        std::vector<Date> dates;
+        std::vector<Rate> rates;
+        dates.push_back(settlementDate);
+        rates.push_back(r[0]);
+        Size i;
+        for (i = 0; i < t.size(); ++i) {
+            dates.push_back(settlementDate + t[i]);
+            rates.push_back(r[i]);
+        }
+
+        // our options
+        Option::Type type(Option::Put);
+        std::vector<Real> underlyings = {15, 20, 25, 30, 35, 40, 45, 50, 55, 60};
+        std::vector<Real> strikes;
+        for (Real s = 10.; s < 80.; s += 1.) {
+            strikes.push_back(s);
+        }
+        Spread dividendYield = 0.01;
+        Date maturity(17, May, 1999);
+        DayCounter dayCounter = Actual365Fixed();
+
+        std::cout.precision(5);
+        constexpr int N = 100;
+
+        // pricing without sensitivities
+        std::cout << "Pricing european equity option portfolio without sensitivities..\n";
+        Real v = 0.0;
+        auto start = std::chrono::high_resolution_clock::now();
+        for (int i = 0; i < N; ++i) {
+            v = priceEuropean(dates, rates, vols, calendar, maturity, strikes, settlementDate,
+                              dayCounter, todaysDate, dividendYield, type, underlyings);
+        }
+        auto end = std::chrono::high_resolution_clock::now();
+        auto time_plain =
+            static_cast<double>(
+                std::chrono::duration_cast<std::chrono::microseconds>(end - start).count()) *
+            1e-3 / N;
+        std::cout << "Portfolio value: " << v << "\n";
+
+        // pricing with sensitivities
+        std::vector<Real> gradient;
+        std::cout << "Pricing european equity option portfolio with sensitivities...\n";
+        OptionSensitivities sensi;
+        Real v2 = 0.0;
+        start = std::chrono::high_resolution_clock::now();
+        for (int i = 0; i < N; ++i) {
+            v2 = priceWithSensi(dates, rates, vols, calendar, maturity, strikes, settlementDate,
+                                dayCounter, todaysDate, dividendYield, type, underlyings, sensi);
+        }
+        end = std::chrono::high_resolution_clock::now();
+        auto time_sensi =
+            static_cast<double>(
+                std::chrono::duration_cast<std::chrono::microseconds>(end - start).count()) *
+            1e-3 / N;
+        std::cout << "Portfolio value: " << v2 << "\n";
+
+        printResults(v2, sensi);
+
+        std::cout << "Plain time : " << time_plain << "ms\n"
+                  << "Sensi time : " << time_sensi << "ms\n"
+                  << "Factor     : " << time_sensi / time_plain << "x\n";
+
+        return 0;
+    } catch (std::exception& e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    } catch (...) {
+        std::cerr << "unknown error" << std::endl;
+        return 1;
+    }
+}

--- a/Examples/AdjointEuropeanEquityOption/CMakeLists.txt
+++ b/Examples/AdjointEuropeanEquityOption/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(
+    AdjointEuropeanEquityOption 
+    AdjointEuropeanEquityOptionXAD.cpp)
+target_link_libraries(AdjointEuropeanEquityOption ql_library)
+if(QL_INSTALL_EXAMPLES)
+    install(TARGETS AdjointEuropeanEquityOption RUNTIME DESTINATION  ${QL_INSTALL_EXAMPLESDIR})
+endif()

--- a/Examples/AdjointHestonModel/AdjointHestonModelXAD.cpp
+++ b/Examples/AdjointHestonModel/AdjointHestonModelXAD.cpp
@@ -20,6 +20,8 @@
 
 /*
 This example uses XAD to calculate sensitivities of a Heston pricer.
+
+TODO: Use the implicit function theorem for calibration with AAD.
 */
 
 #include <ql/qldefines.hpp>

--- a/Examples/AdjointHestonModel/AdjointHestonModelXAD.cpp
+++ b/Examples/AdjointHestonModel/AdjointHestonModelXAD.cpp
@@ -1,0 +1,313 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2023 Xcelerit
+
+ This file is part of QuantLib / XAD integration module.
+ It is modified from QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*
+This example uses XAD to calculate sensitivities of a Heston pricer.
+*/
+
+#include <ql/qldefines.hpp>
+#if !defined(BOOST_ALL_NO_LIB) && defined(BOOST_MSVC)
+#    include <ql/auto_link.hpp>
+#endif
+#include <ql/exercise.hpp>
+#include <ql/math/optimization/levenbergmarquardt.hpp>
+#include <ql/models/equity/hestonmodel.hpp>
+#include <ql/models/equity/hestonmodelhelper.hpp>
+#include <ql/models/equity/piecewisetimedependenthestonmodel.hpp>
+#include <ql/pricingengines/vanilla/analytichestonengine.hpp>
+#include <ql/pricingengines/vanilla/coshestonengine.hpp>
+#include <ql/pricingengines/vanilla/fdhestonvanillaengine.hpp>
+#include <ql/processes/hestonprocess.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/termstructures/yield/zerocurve.hpp>
+#include <ql/termstructures/yieldtermstructure.hpp>
+#include <ql/time/calendars/nullcalendar.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <ql/time/daycounters/actualactual.hpp>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+using namespace QuantLib;
+
+
+struct CalibrationMarketData {
+    Handle<Quote> s0;
+    Handle<YieldTermStructure> riskFreeTS, dividendYield;
+    std::vector<ext::shared_ptr<CalibrationHelper>> options;
+};
+
+CalibrationMarketData getDAXCalibrationMarketData(const std::vector<Date>& dates,
+                                                  const std::vector<Rate>& rates,
+                                                  const std::vector<Real>& dividendYields,
+                                                  const DayCounter& dayCounter,
+                                                  const Calendar& calendar,
+                                                  const std::vector<Integer>& t,
+                                                  const std::vector<Volatility>& v,
+                                                  const std::vector<Real>& strike,
+                                                  const Handle<Quote>& s0) {
+    Handle<YieldTermStructure> riskFreeTS(ext::make_shared<ZeroCurve>(dates, rates, dayCounter));
+
+    Handle<YieldTermStructure> dividendYield(
+        ext::make_shared<ZeroCurve>(dates, dividendYields, dayCounter));
+
+    std::vector<ext::shared_ptr<CalibrationHelper>> options;
+
+    for (Size s = 0; s < 13; ++s) {
+        for (Size m = 0; m < 8; ++m) {
+            Handle<Quote> vol(ext::make_shared<SimpleQuote>(v[s * 8 + m]));
+
+            Period maturity((int)((t[m] + 3) / 7.), Weeks); // round to weeks
+            options.push_back(ext::make_shared<HestonModelHelper>(
+                maturity, calendar, s0, strike[s], vol, riskFreeTS, dividendYield,
+                BlackCalibrationHelper::ImpliedVolError));
+        }
+    }
+
+    return {s0, riskFreeTS, dividendYield, options};
+}
+
+ext::shared_ptr<QuantLib::HestonModel>
+HestonModelCalibration(const std::vector<Date>& dates,
+                       const std::vector<Rate>& rates,
+                       const std::vector<Real>& dividendYield,
+                       const DayCounter& dayCounter,
+                       const Calendar& calendar,
+                       const std::vector<Integer>& t,
+                       const std::vector<Volatility>& v,
+                       const std::vector<Real>& strike,
+                       const Handle<Quote>& s0,
+                       Date settlementDate) {
+    CalibrationMarketData marketData = getDAXCalibrationMarketData(
+        dates, rates, dividendYield, dayCounter, calendar, t, v, strike, s0);
+
+    const Handle<YieldTermStructure> riskFreeTS = marketData.riskFreeTS;
+    const Handle<YieldTermStructure> dividendTS = marketData.dividendYield;
+    const Handle<Quote> S0 = marketData.s0;
+
+    const std::vector<ext::shared_ptr<CalibrationHelper>>& options = marketData.options;
+
+    const Real v0 = 0.5;
+    const Real kappa = 1.0;
+    const Real theta = 0.1;
+    const Real sigma = 0.5;
+    const Real rho = -0.0;
+
+    const auto model = ext::make_shared<HestonModel>(
+        ext::make_shared<HestonProcess>(riskFreeTS, dividendTS, S0, v0, kappa, theta, sigma, rho));
+    auto engine = ext::make_shared<COSHestonEngine>(model);
+
+    const Array params = model->params();
+    model->setParams(params);
+    for (const auto& option : options)
+        ext::dynamic_pointer_cast<BlackCalibrationHelper>(option)->setPricingEngine(engine);
+
+    LevenbergMarquardt om(1e-8, 1e-8, 1e-8);
+    model->calibrate(options, om, EndCriteria(400, 40, 1.0e-8, 1.0e-8, 1.0e-8));
+
+    return model;
+}
+
+Real priceHestonModel(ext::shared_ptr<QuantLib::HestonModel>& model,
+                      const std::vector<Date>& dates,
+                      const std::vector<Rate>& rates,
+                      const std::vector<Real>& dividendYield,
+                      const DayCounter& dayCounter,
+                      const Calendar& calendar,
+                      const std::vector<Integer>& t,
+                      const std::vector<Volatility>& v,
+                      const std::vector<Real>& strike,
+                      const Handle<Quote>& s0,
+                      Date settlementDate) {
+    const Date maturityDate = settlementDate + Period(1, Years);
+
+    const ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(maturityDate);
+
+    const ext::shared_ptr<PricingEngine> cosEngine(
+        ext::make_shared<COSHestonEngine>(model, 25, 600));
+    CalibrationMarketData marketData = getDAXCalibrationMarketData(
+        dates, rates, dividendYield, dayCounter, calendar, t, v, strike, s0);
+
+    const Handle<Quote> S0 = marketData.s0;
+
+    auto payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, S0->value() + 20);
+
+    VanillaOption option(payoff, exercise);
+
+    option.setPricingEngine(cosEngine);
+
+    return option.NPV();
+}
+
+// price with sensitivities
+#ifndef QLXAD_DISABLE_AAD
+
+// create tape
+using tape_type = Real::tape_type;
+tape_type tape;
+
+Real priceWithSensi(const std::vector<Date>& dates,
+                    const std::vector<Rate>& rates,
+                    const std::vector<Real>& dividendYield,
+                    const DayCounter& dayCounter,
+                    const Calendar& calendar,
+                    const std::vector<Integer>& t,
+                    const std::vector<Volatility>& v,
+                    const std::vector<Real>& strike,
+                    const Handle<Quote>& s0,
+                    std::vector<Real>& gradient_v,
+                    std::vector<Real>& gradient_strikes,
+                    std::vector<Real>& gradient_rates,
+                    std::vector<Real>& gradient_dividendYield,
+                    Date settlementDate) {
+    // copy inputs and register them on the tape
+    auto rates_t = rates;
+    auto dividendYield_t = dividendYield;
+    auto strike_t = strike;
+    auto v_t = v;
+    tape.registerInputs(rates_t);
+    tape.registerInputs(dividendYield_t);
+    tape.registerInputs(strike_t);
+    tape.registerInputs(v_t);
+    tape.newRecording();
+
+    auto model = HestonModelCalibration(dates, rates_t, dividendYield_t, dayCounter, calendar, t,
+                                        v_t, strike_t, s0, settlementDate);
+
+    Real value = priceHestonModel(model, dates, rates_t, dividendYield_t, dayCounter, calendar, t,
+                                  v_t, strike_t, s0, settlementDate);
+
+    // register output, set adjoint, and roll-back tape
+    tape.registerOutput(value);
+    derivative(value) = 1.0;
+    tape.computeAdjoints();
+
+    // store derivatives in the gradient vectors
+    std::transform(rates_t.begin(), rates_t.end(), std::back_inserter(gradient_rates),
+                   [](const Real& q) { return derivative(q); });
+    std::transform(dividendYield_t.begin(), dividendYield_t.end(),
+                   std::back_inserter(gradient_dividendYield),
+                   [](const Real& q) { return derivative(q); });
+    std::transform(strike_t.begin(), strike_t.end(), std::back_inserter(gradient_strikes),
+                   [](const Real& q) { return derivative(q); });
+    std::transform(v_t.begin(), v_t.end(), std::back_inserter(gradient_v),
+                   [](const Real& q) { return derivative(q); });
+    return value;
+}
+#endif
+
+void printResults(Real v,
+                  const std::vector<Real>& gradient_v,
+                  const std::vector<Real>& gradient_strikes,
+                  const std::vector<Real>& gradient_rates,
+                  const std::vector<Real>& gradient_dividendYield) {
+
+    std::cout << "Value               = " << v << "\n";
+    std::cout << "strikeSensitivities = [";
+    for (auto& s : gradient_strikes)
+        std::cout << s << ", ";
+    std::cout << "]\n";
+    std::cout << "Rhos                = [";
+    for (auto& s : gradient_rates)
+        std::cout << s << ", ";
+    std::cout << "]\n";
+    std::cout << "dividendRhos        = [";
+    for (auto& s : gradient_dividendYield)
+        std::cout << s << ", ";
+    std::cout << "]\n";
+    std::cout << "Vegas               = [\n";
+    for (auto& s : gradient_v)
+        std::cout << s << "\n";
+    std::cout << "]\n";
+    
+}
+
+int main() {
+
+    try {
+        Date settlementDate(16, September, 2015);
+        Settings::instance().evaluationDate() = settlementDate;
+
+        DayCounter dayCounter = Actual365Fixed();
+        Calendar calendar = TARGET();
+
+        std::vector<Integer> t = {13, 41, 75, 165, 256, 345, 524, 703};
+        std::vector<Rate> r = {0.0357, 0.0349, 0.0341, 0.0355, 0.0359, 0.0368, 0.0386, 0.0401};
+
+        std::vector<Date> dates;
+        std::vector<Rate> rates;
+        dates.push_back(settlementDate);
+        rates.push_back(0.0357);
+        Size i;
+        for (i = 0; i < 8; ++i) {
+            dates.push_back(settlementDate + t[i]);
+            rates.push_back(r[i]);
+        }
+        std::vector<Volatility> v = {
+            0.6625, 0.4875, 0.4204, 0.3668, 0.3431, 0.3267, 0.3121, 0.3121, 0.6007, 0.4543, 0.3967,
+            0.3511, 0.3279, 0.3154, 0.2984, 0.2921, 0.5084, 0.4221, 0.3718, 0.3327, 0.3155, 0.3027,
+            0.2919, 0.2889, 0.4541, 0.3869, 0.3492, 0.3149, 0.2963, 0.2926, 0.2819, 0.2800, 0.4060,
+            0.3607, 0.3330, 0.2999, 0.2887, 0.2811, 0.2751, 0.2775, 0.3726, 0.3396, 0.3108, 0.2781,
+            0.2788, 0.2722, 0.2661, 0.2686, 0.3550, 0.3277, 0.3012, 0.2781, 0.2781, 0.2661, 0.2661,
+            0.2681, 0.3428, 0.3209, 0.2958, 0.2740, 0.2688, 0.2627, 0.2580, 0.2620, 0.3302, 0.3062,
+            0.2799, 0.2631, 0.2573, 0.2533, 0.2504, 0.2544, 0.3343, 0.2959, 0.2705, 0.2540, 0.2504,
+            0.2464, 0.2448, 0.2462, 0.3460, 0.2845, 0.2624, 0.2463, 0.2425, 0.2385, 0.2373, 0.2422,
+            0.3857, 0.2860, 0.2578, 0.2399, 0.2357, 0.2327, 0.2312, 0.2351, 0.3976, 0.2860, 0.2607,
+            0.2356, 0.2297, 0.2268, 0.2241, 0.2320};
+
+        Handle<Quote> s0(ext::make_shared<SimpleQuote>(4468.17));
+        std::vector<Real> strike = {3401, 4000, 4400, 5000, 5600};
+
+        std::vector<Real> dividendYield = {0.11,   0.12,   0.13,   0.124, 0.1245,
+                                           0.1537, 0.1458, 0.1874, 0.1656};
+
+        std::cout.precision(6);
+
+#ifdef QLXAD_DISABLE_AAD
+        std::cout << "Pricing with Heston COS engine, no sensitivities...\n";
+        auto model = HestonModelCalibration(dates, rates, dividendYield, dayCounter, calendar, t, v,
+                                            strike, s0, settlementDate);
+        Real value = priceHestonModel(model, dates, rates, dividendYield, dayCounter, calendar, t,
+                                      v, strike, s0, settlementDate);
+        std::cout << "Value : " << value << "\n";
+#else
+        std::vector<Real> gradient_v;
+        std::vector<Real> gradient_rates;
+        std::vector<Real> gradient_dividendYield;
+        std::vector<Real> gradient_strikes;
+        std::cout << "Pricing with Heston COS engine, with sensitivities...\n";
+        Real value = priceWithSensi(dates, rates, dividendYield, dayCounter, calendar, t, v, strike,
+                                    s0, gradient_v, gradient_strikes, gradient_rates,
+                                    gradient_dividendYield, settlementDate);
+        printResults(value, gradient_v, gradient_strikes, gradient_rates, gradient_dividendYield);
+#endif
+
+        return 0;
+    } catch (std::exception& e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    } catch (...) {
+        std::cerr << "unknown error" << std::endl;
+        return 1;
+    }
+}

--- a/Examples/AdjointHestonModel/CMakeLists.txt
+++ b/Examples/AdjointHestonModel/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(
+    AdjointHestonModel 
+    AdjointHestonModelXAD.cpp)
+target_link_libraries(AdjointHestonModel ql_library)
+if(QL_INSTALL_EXAMPLES)
+    install(TARGETS AdjointHestonModel RUNTIME DESTINATION  ${QL_INSTALL_EXAMPLESDIR})
+endif()

--- a/Examples/AdjointMulticurveBootstrapping/AdjointMulticurveBootstrappingXAD.cpp
+++ b/Examples/AdjointMulticurveBootstrapping/AdjointMulticurveBootstrappingXAD.cpp
@@ -1,0 +1,603 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2000, 2001, 2002, 2003 RiskMap srl
+ Copyright (C) 2003, 2004, 2005, 2006, 2007 StatPro Italia srl
+ Copyright (C) 2004 Ferdinando Ametrano
+ Copyright (C) 2018 Jose Garcia
+ Copyright (C) 2023 Xcelerit
+
+ This file is part of QuantLib / XAD integration module.
+ It is modified from QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*
+This example demonstrates how to use XAD to calculate sensitivities to
+market quotes when multi-curve bootstrapping is used from many input
+quotes.
+It also measures the performance for calculating sensitivities,
+either with XAD or with plain doubles and bumping (when QLXAD_DISABLE_AAD is ON).
+*/
+
+#include <ql/qldefines.hpp>
+#if !defined(BOOST_ALL_NO_LIB) && defined(BOOST_MSVC)
+#    include <ql/auto_link.hpp>
+#endif
+#include <ql/exercise.hpp>
+#include <ql/indexes/ibor/eonia.hpp>
+#include <ql/indexes/ibor/euribor.hpp>
+#include <ql/math/interpolations/cubicinterpolation.hpp>
+#include <ql/math/interpolations/loginterpolation.hpp>
+#include <ql/pricingengines/swap/discountingswapengine.hpp>
+#include <ql/termstructures/yield/oisratehelper.hpp>
+#include <ql/termstructures/yield/piecewiseyieldcurve.hpp>
+#include <ql/termstructures/yield/ratehelpers.hpp>
+#include <ql/termstructures/yieldtermstructure.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <ql/time/daycounters/actualactual.hpp>
+#include <ql/time/daycounters/thirty360.hpp>
+#include <ql/time/imm.hpp>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+
+using namespace QuantLib;
+
+
+Real priceMulricurveBootstrappingSwap(const std::vector<Real>& depos,
+                                      const Calendar& calendar,
+                                      const std::vector<Real>& shortOis,
+                                      const std::vector<Real>& datesOIS,
+                                      const std::vector<Real>& longTermOIS,
+                                      Date todaysDate,
+                                      const DayCounter& termStructureDayCounter,
+                                      Real d6MRate,
+                                      const std::vector<Real>& fra,
+                                      const std::vector<Real>& swapRates,
+                                      Date settlementDate,
+                                      Date maturity,
+                                      Real nominal,
+                                      Real fixedRate,
+                                      Real spread,
+                                      Integer lengthInYears) {
+    auto eonia = ext::make_shared<Eonia>();
+    std::vector<ext::shared_ptr<RateHelper>> eoniaInstruments;
+    // deposits
+    std::map<Natural, ext::shared_ptr<Quote>> depoQuotes = {
+        // settlement days, quote
+        {0, ext::make_shared<SimpleQuote>(depos[0])},
+        {1, ext::make_shared<SimpleQuote>(depos[1])},
+        {2, ext::make_shared<SimpleQuote>(depos[2])}};
+
+    DayCounter depositDayCounter = Actual360();
+
+    for (const auto& q : depoQuotes) {
+        auto settlementDays = q.first;
+        auto quote = q.second;
+        auto helper =
+            ext::make_shared<DepositRateHelper>(Handle<Quote>(quote), 1 * Days, settlementDays,
+                                                calendar, Following, false, depositDayCounter);
+        eoniaInstruments.push_back(helper);
+    }
+
+    // short-term OIS
+    std::map<Period, ext::shared_ptr<Quote>> shortOisQuotes = {
+        {1 * Weeks, ext::make_shared<SimpleQuote>(shortOis[0])},
+        {2 * Weeks, ext::make_shared<SimpleQuote>(shortOis[1])},
+        {3 * Weeks, ext::make_shared<SimpleQuote>(shortOis[2])},
+        {1 * Months, ext::make_shared<SimpleQuote>(shortOis[3])}};
+
+    for (const auto& q : shortOisQuotes) {
+        auto tenor = q.first;
+        auto quote = q.second;
+        auto helper = ext::make_shared<OISRateHelper>(2, tenor, Handle<Quote>(quote), eonia);
+        eoniaInstruments.push_back(helper);
+    }
+
+    // Dated OIS
+    std::map<std::pair<Date, Date>, ext::shared_ptr<Quote>> datedOisQuotes = {
+        {{Date(16, January, 2013), Date(13, February, 2013)},
+         ext::make_shared<SimpleQuote>(datesOIS[0])},
+        {{Date(13, February, 2013), Date(13, March, 2013)},
+         ext::make_shared<SimpleQuote>(datesOIS[1])},
+        {{Date(13, March, 2013), Date(10, April, 2013)},
+         ext::make_shared<SimpleQuote>(datesOIS[2])},
+        {{Date(10, April, 2013), Date(8, May, 2013)}, ext::make_shared<SimpleQuote>(datesOIS[3])},
+        {{Date(8, May, 2013), Date(12, June, 2013)}, ext::make_shared<SimpleQuote>(datesOIS[4])},
+    };
+
+    for (const auto& q : datedOisQuotes) {
+        auto startDate = q.first.first;
+        auto endDate = q.first.second;
+        auto quote = q.second;
+        auto helper =
+            ext::make_shared<DatedOISRateHelper>(startDate, endDate, Handle<Quote>(quote), eonia);
+        eoniaInstruments.push_back(helper);
+    }
+
+    // long-term OIS
+    std::map<Period, ext::shared_ptr<Quote>> longOisQuotes = {
+        {15 * Months, ext::make_shared<SimpleQuote>(longTermOIS[0])},
+        {18 * Months, ext::make_shared<SimpleQuote>(longTermOIS[1])},
+        {21 * Months, ext::make_shared<SimpleQuote>(longTermOIS[2])},
+        {2 * Years, ext::make_shared<SimpleQuote>(longTermOIS[3])},
+        {3 * Years, ext::make_shared<SimpleQuote>(longTermOIS[4])},
+        {4 * Years, ext::make_shared<SimpleQuote>(longTermOIS[5])},
+        {5 * Years, ext::make_shared<SimpleQuote>(longTermOIS[6])},
+        {6 * Years, ext::make_shared<SimpleQuote>(longTermOIS[7])},
+        {7 * Years, ext::make_shared<SimpleQuote>(longTermOIS[8])},
+        {8 * Years, ext::make_shared<SimpleQuote>(longTermOIS[9])},
+        {9 * Years, ext::make_shared<SimpleQuote>(longTermOIS[10])},
+        {10 * Years, ext::make_shared<SimpleQuote>(longTermOIS[11])},
+        {11 * Years, ext::make_shared<SimpleQuote>(longTermOIS[12])},
+        {12 * Years, ext::make_shared<SimpleQuote>(longTermOIS[13])},
+        {15 * Years, ext::make_shared<SimpleQuote>(longTermOIS[14])},
+        {20 * Years, ext::make_shared<SimpleQuote>(longTermOIS[15])},
+        {25 * Years, ext::make_shared<SimpleQuote>(longTermOIS[16])},
+        {30 * Years, ext::make_shared<SimpleQuote>(longTermOIS[17])}};
+
+    for (const auto& q : longOisQuotes) {
+        auto tenor = q.first;
+        auto quote = q.second;
+        auto helper = ext::make_shared<OISRateHelper>(2, tenor, Handle<Quote>(quote), eonia);
+        eoniaInstruments.push_back(helper);
+    }
+    // curve
+    auto eoniaTermStructure = ext::make_shared<PiecewiseYieldCurve<Discount, Cubic>>(
+        todaysDate, eoniaInstruments, termStructureDayCounter);
+
+    eoniaTermStructure->enableExtrapolation();
+
+    // This curve will be used for discounting cash flows
+    RelinkableHandle<YieldTermStructure> discountingTermStructure;
+    discountingTermStructure.linkTo(eoniaTermStructure);
+
+    std::vector<ext::shared_ptr<RateHelper>> euribor6MInstruments;
+
+    auto euribor6M = ext::make_shared<Euribor6M>();
+
+    auto d6M = ext::make_shared<DepositRateHelper>(
+        Handle<Quote>(ext::make_shared<SimpleQuote>(d6MRate)), 6 * Months, 3, calendar, Following,
+        false, depositDayCounter);
+
+    euribor6MInstruments.push_back(d6M);
+
+    // FRAs
+    std::map<Natural, ext::shared_ptr<Quote>> fraQuotes = {
+        {1, ext::make_shared<SimpleQuote>(fra[0])},   {2, ext::make_shared<SimpleQuote>(fra[1])},
+        {3, ext::make_shared<SimpleQuote>(fra[2])},   {4, ext::make_shared<SimpleQuote>(fra[3])},
+        {5, ext::make_shared<SimpleQuote>(fra[4])},   {6, ext::make_shared<SimpleQuote>(fra[5])},
+        {7, ext::make_shared<SimpleQuote>(fra[6])},   {8, ext::make_shared<SimpleQuote>(fra[7])},
+        {9, ext::make_shared<SimpleQuote>(fra[8])},   {10, ext::make_shared<SimpleQuote>(fra[9])},
+        {11, ext::make_shared<SimpleQuote>(fra[10])}, {12, ext::make_shared<SimpleQuote>(fra[11])},
+        {13, ext::make_shared<SimpleQuote>(fra[12])}, {14, ext::make_shared<SimpleQuote>(fra[13])},
+        {15, ext::make_shared<SimpleQuote>(fra[14])}, {16, ext::make_shared<SimpleQuote>(fra[15])},
+        {17, ext::make_shared<SimpleQuote>(fra[16])}, {18, ext::make_shared<SimpleQuote>(fra[17])}};
+
+    for (const auto& q : fraQuotes) {
+        auto monthsToStart = q.first;
+        auto quote = q.second;
+        auto helper =
+            ext::make_shared<FraRateHelper>(Handle<Quote>(quote), monthsToStart, euribor6M);
+        euribor6MInstruments.push_back(helper);
+    }
+    // swaps
+    std::map<Period, ext::shared_ptr<Quote>> swapQuotes = {
+        {3 * Years, ext::make_shared<SimpleQuote>(swapRates[0])},
+        {4 * Years, ext::make_shared<SimpleQuote>(swapRates[1])},
+        {5 * Years, ext::make_shared<SimpleQuote>(swapRates[2])},
+        {6 * Years, ext::make_shared<SimpleQuote>(swapRates[3])},
+        {7 * Years, ext::make_shared<SimpleQuote>(swapRates[4])},
+        {8 * Years, ext::make_shared<SimpleQuote>(swapRates[5])},
+        {9 * Years, ext::make_shared<SimpleQuote>(swapRates[6])},
+        {10 * Years, ext::make_shared<SimpleQuote>(swapRates[7])},
+        {12 * Years, ext::make_shared<SimpleQuote>(swapRates[8])},
+        {15 * Years, ext::make_shared<SimpleQuote>(swapRates[9])},
+        {20 * Years, ext::make_shared<SimpleQuote>(swapRates[10])},
+        {25 * Years, ext::make_shared<SimpleQuote>(swapRates[11])},
+        {30 * Years, ext::make_shared<SimpleQuote>(swapRates[12])},
+        {35 * Years, ext::make_shared<SimpleQuote>(swapRates[13])},
+        {40 * Years, ext::make_shared<SimpleQuote>(swapRates[14])},
+        {50 * Years, ext::make_shared<SimpleQuote>(swapRates[15])},
+        {60 * Years, ext::make_shared<SimpleQuote>(swapRates[16])}};
+
+    Frequency swFixedLegFrequency = Annual;
+    BusinessDayConvention swFixedLegConvention = Unadjusted;
+    DayCounter swFixedLegDayCounter = Thirty360(Thirty360::European);
+
+    for (const auto& q : swapQuotes) {
+        auto tenor = q.first;
+        auto quote = q.second;
+        auto helper = ext::make_shared<SwapRateHelper>(
+            Handle<Quote>(quote), tenor, calendar, swFixedLegFrequency, swFixedLegConvention,
+            swFixedLegDayCounter, euribor6M, Handle<Quote>(), 0 * Days,
+            discountingTermStructure); // the Eonia curve is used for discounting
+        euribor6MInstruments.push_back(helper);
+    }
+    double tolerance = 1.0e-15;
+    auto euribor6MTermStructure = ext::make_shared<PiecewiseYieldCurve<Discount, Cubic>>(
+        settlementDate, euribor6MInstruments, termStructureDayCounter,
+        PiecewiseYieldCurve<Discount, Cubic>::bootstrap_type(tolerance));
+
+    RelinkableHandle<YieldTermStructure> forecastingTermStructure;
+    forecastingTermStructure.linkTo(euribor6MTermStructure);
+    auto euriborIndex = ext::make_shared<Euribor6M>(forecastingTermStructure);
+    Schedule fixedSchedule(settlementDate, maturity, Period(Annual), calendar, Unadjusted,
+                           Unadjusted, DateGeneration::Forward, false);
+    Schedule floatSchedule(settlementDate, maturity, Period(Semiannual), calendar,
+                           ModifiedFollowing, ModifiedFollowing, DateGeneration::Forward, false);
+    VanillaSwap spot5YearSwap(Swap::Payer, nominal, fixedSchedule, fixedRate,
+                              Thirty360(Thirty360::European), floatSchedule, euriborIndex, spread,
+                              Actual360());
+
+    Date fwdStart = calendar.advance(settlementDate, 1, Years);
+    Date fwdMaturity = fwdStart + lengthInYears * Years;
+    Schedule fwdFixedSchedule(fwdStart, fwdMaturity, Period(Annual), calendar, Unadjusted,
+                              Unadjusted, DateGeneration::Forward, false);
+    Schedule fwdFloatSchedule(fwdStart, fwdMaturity, Period(Semiannual), calendar,
+                              ModifiedFollowing, ModifiedFollowing, DateGeneration::Forward, false);
+    VanillaSwap oneYearForward5YearSwap(Swap::Payer, nominal, fwdFixedSchedule, fixedRate,
+                                        Thirty360(Thirty360::European), fwdFloatSchedule,
+                                        euriborIndex, spread, Actual360());
+    auto s5yRate = swapQuotes[5 * Years];
+    ext::shared_ptr<PricingEngine> swapEngine(new DiscountingSwapEngine(discountingTermStructure));
+
+    spot5YearSwap.setPricingEngine(swapEngine);
+    oneYearForward5YearSwap.setPricingEngine(swapEngine);
+
+    return spot5YearSwap.NPV();
+}
+
+#ifndef QLXAD_DISABLE_AAD
+
+// create tape
+using tape_type = Real::tape_type;
+tape_type tape;
+
+Real priceWithSensi(const std::vector<Real>& depos,
+                    const Calendar& calendar,
+                    const std::vector<Real>& shortOis,
+                    const std::vector<Real>& datesOIS,
+                    const std::vector<Real>& longTermOIS,
+                    Date todaysDate,
+                    const DayCounter& termStructureDayCounter,
+                    Real d6MRate,
+                    const std::vector<Real>& fra,
+                    const std::vector<Real>& swapRates,
+                    Date settlementDate,
+                    Date maturity,
+                    Real nominal,
+                    Real fixedRate,
+                    Real spread,
+                    Integer lengthInYears,
+                    std::vector<Real>& gradient) {
+    // clear the tape and gradient to allow for re-running this in a loop
+    tape.clearAll();
+    gradient.clear();
+
+    // copy independent variables and register them with the tape
+    auto depos_t = depos;
+    auto shortOis_t = shortOis;
+    auto datesOIS_t = datesOIS;
+    auto longTermOIS_t = longTermOIS;
+    auto swapRates_t = swapRates;
+    auto fra_t = fra;
+    tape.registerInputs(depos_t);
+    tape.registerInputs(shortOis_t);
+    tape.registerInputs(datesOIS_t);
+    tape.registerInputs(longTermOIS_t);
+    tape.registerInputs(swapRates_t);
+    tape.registerInputs(fra_t);
+    tape.registerInput(fixedRate);
+    tape.registerInput(spread);
+    tape.registerInput(nominal);
+    tape.registerInput(d6MRate);
+    tape.newRecording();
+
+    Real value = priceMulricurveBootstrappingSwap(
+        depos_t, calendar, shortOis_t, datesOIS_t, longTermOIS_t, todaysDate,
+        termStructureDayCounter, d6MRate, fra_t, swapRates_t, settlementDate, maturity, nominal,
+        fixedRate, spread, lengthInYears);
+
+    // register output, set its adjoint, and roll-back the tape
+    tape.registerOutput(value);
+    derivative(value) = 1.0;
+    tape.computeAdjoints();
+
+    // obtain the sensitivities (input adjonits)
+    for (auto& g : depos_t)
+        gradient.push_back(derivative(g));
+
+    for (auto& g : shortOis_t)
+        gradient.push_back(derivative(g));
+
+    for (auto& g : datesOIS_t)
+        gradient.push_back(derivative(g));
+
+    for (auto& g : longTermOIS_t)
+        gradient.push_back(derivative(g));
+
+    for (auto& g : swapRates_t)
+        gradient.push_back(derivative(g));
+
+    for (auto& g : fra_t)
+        gradient.push_back(derivative(g));
+
+
+    gradient.push_back(derivative(fixedRate));
+    gradient.push_back(derivative(spread));
+    gradient.push_back(derivative(nominal));
+    gradient.push_back(derivative(d6MRate));
+
+    return value;
+}
+
+
+#else
+
+Real priceWithSensi(const std::vector<Real>& depos,
+                    const Calendar& calendar,
+                    const std::vector<Real>& shortOis,
+                    const std::vector<Real>& datesOIS,
+                    const std::vector<Real>& longTermOIS,
+                    Date todaysDate,
+                    const DayCounter& termStructureDayCounter,
+                    Real d6MRate,
+                    const std::vector<Real>& fra,
+                    const std::vector<Real>& swapRates,
+                    Date settlementDate,
+                    Date maturity,
+                    Real nominal,
+                    Real fixedRate,
+                    Real spread,
+                    Integer lengthInYears,
+                    std::vector<Real>& gradient) {
+    Real value = priceMulricurveBootstrappingSwap(depos, calendar, shortOis, datesOIS, longTermOIS,
+                                                  todaysDate, termStructureDayCounter, d6MRate, fra,
+                                                  swapRates, settlementDate, maturity, nominal,
+                                                  fixedRate, spread, lengthInYears);
+
+    // bump each value and calculate the sensitivities using finite differences
+    Real eps = 1e-5;
+    auto depos_t = depos;
+    for (std::size_t i = 0; i < depos.size(); ++i) {
+        depos_t[i] += eps;
+        Real v1 = priceMulricurveBootstrappingSwap(
+            depos_t, calendar, shortOis, datesOIS, longTermOIS, todaysDate, termStructureDayCounter,
+            d6MRate, fra, swapRates, settlementDate, maturity, nominal, fixedRate, spread,
+            lengthInYears);
+        gradient.push_back((v1 - value) / eps);
+        depos_t[i] -= eps;
+    }
+
+    auto shortOis_t = shortOis;
+    for (std::size_t i = 0; i < shortOis.size(); ++i) {
+        shortOis_t[i] += eps;
+        Real v1 = priceMulricurveBootstrappingSwap(
+            depos, calendar, shortOis_t, datesOIS, longTermOIS, todaysDate, termStructureDayCounter,
+            d6MRate, fra, swapRates, settlementDate, maturity, nominal, fixedRate, spread,
+            lengthInYears);
+        gradient.push_back((v1 - value) / eps);
+        shortOis_t[i] -= eps;
+    }
+
+    auto datesOIS_t = datesOIS;
+    for (std::size_t i = 0; i < datesOIS.size(); ++i) {
+        datesOIS_t[i] += eps;
+        Real v1 = priceMulricurveBootstrappingSwap(
+            depos, calendar, shortOis, datesOIS_t, longTermOIS, todaysDate, termStructureDayCounter,
+            d6MRate, fra, swapRates, settlementDate, maturity, nominal, fixedRate, spread,
+            lengthInYears);
+        gradient.push_back((v1 - value) / eps);
+        datesOIS_t[i] -= eps;
+    }
+
+    auto longTermOIS_t = longTermOIS;
+    for (std::size_t i = 0; i < longTermOIS.size(); ++i) {
+        longTermOIS_t[i] += eps;
+        Real v1 = priceMulricurveBootstrappingSwap(
+            depos, calendar, shortOis, datesOIS, longTermOIS_t, todaysDate, termStructureDayCounter,
+            d6MRate, fra, swapRates, settlementDate, maturity, nominal, fixedRate, spread,
+            lengthInYears);
+        gradient.push_back((v1 - value) / eps);
+        longTermOIS_t[i] -= eps;
+    }
+
+    auto swapRates_t = swapRates;
+    for (std::size_t i = 0; i < swapRates.size(); ++i) {
+        swapRates_t[i] += eps;
+        Real v1 = priceMulricurveBootstrappingSwap(depos, calendar, shortOis, datesOIS, longTermOIS,
+                                                   todaysDate, termStructureDayCounter, d6MRate,
+                                                   fra, swapRates_t, settlementDate, maturity,
+                                                   nominal, fixedRate, spread, lengthInYears);
+        gradient.push_back((v1 - value) / eps);
+        swapRates_t[i] -= eps;
+    }
+
+    auto fra_t = fra;
+    for (std::size_t i = 0; i < fra.size(); ++i) {
+        fra_t[i] += eps;
+        Real v1 = priceMulricurveBootstrappingSwap(depos, calendar, shortOis, datesOIS, longTermOIS,
+                                                   todaysDate, termStructureDayCounter, d6MRate,
+                                                   fra_t, swapRates, settlementDate, maturity,
+                                                   nominal, fixedRate, spread, lengthInYears);
+        gradient.push_back((v1 - value) / eps);
+        fra_t[i] -= eps;
+    }
+
+    Real v1 = priceMulricurveBootstrappingSwap(depos, calendar, shortOis, datesOIS, longTermOIS,
+                                               todaysDate, termStructureDayCounter, d6MRate, fra,
+                                               swapRates, settlementDate, maturity, nominal,
+                                               fixedRate + eps, spread, lengthInYears);
+    gradient.push_back((v1 - value) / eps);
+
+    v1 = priceMulricurveBootstrappingSwap(depos, calendar, shortOis, datesOIS, longTermOIS,
+                                          todaysDate, termStructureDayCounter, d6MRate, fra,
+                                          swapRates, settlementDate, maturity, nominal, fixedRate,
+                                          spread + eps, lengthInYears);
+    gradient.push_back((v1 - value) / eps);
+
+    v1 = priceMulricurveBootstrappingSwap(depos, calendar, shortOis, datesOIS, longTermOIS,
+                                          todaysDate, termStructureDayCounter, d6MRate, fra,
+                                          swapRates, settlementDate, maturity, nominal + eps,
+                                          fixedRate, spread, lengthInYears);
+    gradient.push_back((v1 - value) / eps);
+
+    v1 = priceMulricurveBootstrappingSwap(depos, calendar, shortOis, datesOIS, longTermOIS,
+                                          todaysDate, termStructureDayCounter, d6MRate + eps, fra,
+                                          swapRates, settlementDate, maturity, nominal, fixedRate,
+                                          spread, lengthInYears);
+    gradient.push_back((v1 - value) / eps);
+
+    return value;
+}
+
+
+#endif
+
+
+void printResults(Real v,
+                  const std::vector<Real>& gradient,
+                  Size nDepos,
+                  Size nShortOis,
+                  Size ndatesOIS,
+                  Size nlongOIS,
+                  Size nSwapRates,
+                  Size nFRA) {
+    std::cout << "Price                                 = " << v << "\n";
+    std::cout << "Sensitivities w.r.t. depo quotes      = [";
+    Size cnt = 0;
+    for (Size i = cnt; i < cnt + nDepos; ++i)
+        std::cout << gradient[i] << ", ";
+    cnt += nDepos;
+    std::cout << "]\n";
+    std::cout << "Sensitivities w.r.t. short OIS quotes = [";
+    for (Size i = cnt; i < cnt + nShortOis; ++i)
+        std::cout << gradient[i] << ", ";
+    cnt += nShortOis;
+    std::cout << "]\n";
+    std::cout << "Sensitivities w.r.t. date OIS quotes = [";
+    for (Size i = cnt; i < cnt + ndatesOIS; ++i)
+        std::cout << gradient[i] << ", ";
+    cnt += ndatesOIS;
+    std::cout << "]\n";
+    std::cout << "Sensitivities w.r.t. long OIS quotes = [";
+    for (Size i = cnt; i < cnt + nlongOIS; ++i)
+        std::cout << gradient[i] << ", ";
+    cnt += nlongOIS;
+    std::cout << "]\n";
+    std::cout << "Sensitivities w.r.t. swap quotes    = [";
+    for (Size i = cnt; i < cnt + nSwapRates; ++i)
+        std::cout << gradient[i] << ", ";
+    cnt += nSwapRates;
+    std::cout << "]\n";
+    std::cout << "Sensitivities w.r.t. FRA quotes     = [";
+    for (Size i = cnt; i < cnt + nFRA; ++i)
+        std::cout << gradient[i] << ", ";
+    cnt += nFRA;
+    std::cout << "]\n";
+    std::cout << "Sensitivity w.r.t. swap fixed Rate  = " << gradient[cnt++] << "\n";
+    std::cout << "Sensitivity w.r.t. swap spread      = " << gradient[cnt++] << "\n";
+    std::cout << "Sensitivity w.r.t. swap nominal     = " << gradient[cnt++] << "\n";
+    std::cout << "Sensitivity w.r.t. swap d6Mrate     = " << gradient[cnt++] << "\n";
+}
+
+int main(int, char*[]) {
+
+    try {
+
+        Calendar calendar = TARGET();
+
+        Date todaysDate(11, December, 2012);
+        Settings::instance().evaluationDate() = todaysDate;
+        todaysDate = Settings::instance().evaluationDate();
+
+        Integer fixingDays = 2;
+        Date settlementDate = calendar.advance(todaysDate, fixingDays, Days);
+        // must be a business day
+        settlementDate = calendar.adjust(settlementDate);
+
+        // EONIA CURVE
+        DayCounter termStructureDayCounter = Actual365Fixed();
+        std::vector<Real> depos = {0.0004, 0.0004, 0.0004};
+        std::vector<Real> shortOis = {0.00070, 0.00069, 0.00078, 0.00074};
+        std::vector<Real> datesOIS = {0.000460, 0.000160, -0.000070, -0.000130, -0.000140};
+        std::vector<Real> longTermOIS = {0.00002, 0.00008, 0.00021, 0.00036, 0.00127, 0.00274,
+                                         0.00456, 0.00647, 0.00827, 0.00996, 0.01147, 0.0128,
+                                         0.01404, 0.01516, 0.01764, 0.01939, 0.02003, 0.02038};
+        Real d6MRate = 0.00312;
+        std::vector<Real> fra = {0.002930, 0.002720, 0.002600, 0.002560, 0.002520, 0.002480,
+                                 0.002540, 0.002610, 0.002670, 0.002790, 0.002910, 0.003030,
+                                 0.003180, 0.003350, 0.003520, 0.003710, 0.003890, 0.004090};
+        std::vector<Real> swapRates = {0.004240, 0.005760, 0.007620, 0.009540, 0.011350, 0.013030,
+                                       0.014520, 0.015840, 0.018090, 0.020370, 0.021870, 0.022340,
+                                       0.022560, 0.022950, 0.023480, 0.024210, 0.024630};
+        Real nominal = 1000000.0;
+        Spread spread = 0.0;
+        Rate fixedRate = 0.007;
+        Integer lengthInYears = 5;
+        Date maturity = settlementDate + lengthInYears * Years;
+
+        std::cout.precision(5);
+        constexpr int N = 20;
+
+
+        std::cout << "Pricing swap with multicurve bootstrapping without sensitivities...\n";
+        Real v = 0.0;
+        auto start = std::chrono::high_resolution_clock::now();
+        for (int i = 0; i < N; ++i) {
+            v = priceMulricurveBootstrappingSwap(depos, calendar, shortOis, datesOIS, longTermOIS,
+                                                 todaysDate, termStructureDayCounter, d6MRate, fra,
+                                                 swapRates, settlementDate, maturity, nominal,
+                                                 fixedRate, spread, lengthInYears);
+        }
+        auto end = std::chrono::high_resolution_clock::now();
+        auto time_plain =
+            static_cast<double>(
+                std::chrono::duration_cast<std::chrono::microseconds>(end - start).count()) *
+            1e-3 / N;
+        std::cout << "Value = " << v << "\n";
+
+        // pricing with AAD
+        std::vector<Real> gradient;
+        std::cout << "Pricing swap with multicurve bootstrapping with sensitivities...\n";
+        Real v2 = 0.0;
+        start = std::chrono::high_resolution_clock::now();
+        for (int i = 0; i < N; ++i) {
+            v2 = priceWithSensi(depos, calendar, shortOis, datesOIS, longTermOIS, todaysDate,
+                                termStructureDayCounter, d6MRate, fra, swapRates, settlementDate,
+                                maturity, nominal, fixedRate, spread, lengthInYears, gradient);
+        }
+        end = std::chrono::high_resolution_clock::now();
+        auto time_sensi =
+            static_cast<double>(
+                std::chrono::duration_cast<std::chrono::microseconds>(end - start).count()) *
+            1e-3 / N;
+
+        printResults(v2, gradient, depos.size(), shortOis.size(), datesOIS.size(),
+                     longTermOIS.size(), swapRates.size(), fra.size());
+
+        std::cout << "Plain time : " << time_plain << "ms\n"
+                  << "Sensi time : " << time_sensi << "ms\n"
+                  << "Factor     : " << time_sensi / time_plain << "x\n";
+        return 0;
+    } catch (std::exception& e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    } catch (...) {
+        std::cerr << "unknown error" << std::endl;
+        return 1;
+    }
+}

--- a/Examples/AdjointMulticurveBootstrapping/CMakeLists.txt
+++ b/Examples/AdjointMulticurveBootstrapping/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(
+    AdjointMulticurveBootstrapping 
+    AdjointMulticurveBootstrappingXAD.cpp)
+target_link_libraries(AdjointMulticurveBootstrapping ql_library)
+if(QL_INSTALL_EXAMPLES)
+    install(TARGETS AdjointMulticurveBootstrapping RUNTIME DESTINATION  ${QL_INSTALL_EXAMPLESDIR})
+endif()

--- a/Examples/AdjointReplication/AdjointReplicationXAD.cpp
+++ b/Examples/AdjointReplication/AdjointReplicationXAD.cpp
@@ -1,0 +1,384 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2006, 2007 StatPro Italia srl
+ Copyright (C) 2023 Xcelerit
+
+ This file is part of QuantLib / XAD integration module.
+ It is modified from QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*
+This example is an AAD-enabled version for the Replication sample that ships with
+QuantLib. It calculates sensitivities using XAD and measures peformance.
+When QLXAD_DISABLE_AAD is ON, it calculates the sensitivities using finite differences.
+*/
+
+#include <ql/qldefines.hpp>
+#if !defined(BOOST_ALL_NO_LIB) && defined(BOOST_MSVC)
+#    include <ql/auto_link.hpp>
+#endif
+#include <ql/exercise.hpp>
+#include <ql/instruments/barrieroption.hpp>
+#include <ql/instruments/compositeinstrument.hpp>
+#include <ql/instruments/europeanoption.hpp>
+#include <ql/pricingengines/barrier/analyticbarrierengine.hpp>
+#include <ql/pricingengines/vanilla/analyticeuropeanengine.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/termstructures/volatility/equityfx/blackconstantvol.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/termstructures/yield/zerocurve.hpp>
+#include <ql/time/calendars/nullcalendar.hpp>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+using namespace QuantLib;
+
+
+Real priceBarrierOption(std::vector<Date>& dates,
+                        std::vector<Real>& rates,
+                        DayCounter& dayCounter,
+                        Date& maturity,
+                        Real& strike,
+                        Option::Type& type,
+                        Barrier::Type& barrierType,
+                        Real& underlying,
+                        Real& v,
+                        Real& barrier,
+                        Real& rebate) {
+
+    auto underlyingH = ext::make_shared<SimpleQuote>(underlying);
+    auto volatility = ext::make_shared<SimpleQuote>(v);
+    Handle<Quote> h2(volatility);
+
+    Handle<YieldTermStructure> ratesYield(ext::make_shared<ZeroCurve>(dates, rates, dayCounter));
+    Handle<BlackVolTermStructure> flatVol(
+        ext::make_shared<BlackConstantVol>(0, NullCalendar(), h2, dayCounter));
+
+    // instantiate the option
+    auto exercise = ext::make_shared<EuropeanExercise>(maturity);
+    auto payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
+
+    auto bsProcess =
+        ext::make_shared<BlackScholesProcess>(Handle<Quote>(underlyingH), ratesYield, flatVol);
+    // option
+    auto referenceOption =
+        ext::make_shared<BarrierOption>(barrierType, barrier, rebate, payoff, exercise);
+
+    referenceOption->setPricingEngine(ext::make_shared<AnalyticBarrierEngine>(bsProcess));
+
+    return referenceOption->NPV();
+}
+
+Real pricePortfolio(const std::vector<Date>& dates,
+                    const std::vector<Real>& riskFreeRates,
+                    const DayCounter& dayCounter,
+                    Date maturity,
+                    Real strike,
+                    Option::Type type,
+                    Barrier::Type barrierType,
+                    Real underlying,
+                    Real v,
+                    Real barrier,
+                    Real rebate,
+                    Integer B,
+                    Integer t,
+                    TimeUnit timeUnit,
+                    Date& today) {
+    CompositeInstrument portfolio;
+    auto underlyingH = ext::make_shared<SimpleQuote>(underlying);
+    auto volatility = ext::make_shared<SimpleQuote>(v);
+    Handle<Quote> h2(volatility);
+
+    Handle<YieldTermStructure> ratesYield(
+        ext::make_shared<ZeroCurve>(dates, riskFreeRates, dayCounter));
+    Handle<BlackVolTermStructure> flatVol(
+        ext::make_shared<BlackConstantVol>(0, NullCalendar(), h2, dayCounter));
+
+    // instantiate the option
+    auto exercise = ext::make_shared<EuropeanExercise>(maturity);
+    auto payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
+
+    auto bsProcess =
+        ext::make_shared<BlackScholesProcess>(Handle<Quote>(underlyingH), ratesYield, flatVol);
+
+    auto europeanEngine = ext::make_shared<AnalyticEuropeanEngine>(bsProcess);
+    // Final payoff first as shown in Joshi, a put struck at K...
+    auto put1 = ext::make_shared<EuropeanOption>(payoff, exercise);
+    put1->setPricingEngine(europeanEngine);
+    portfolio.add(put1);
+    // ...minus a digital put struck at B of notional K-B...
+    auto digitalPayoff = ext::make_shared<CashOrNothingPayoff>(Option::Put, barrier, 1.0);
+    auto digitalPut = ext::make_shared<EuropeanOption>(digitalPayoff, exercise);
+    digitalPut->setPricingEngine(europeanEngine);
+    portfolio.subtract(digitalPut, strike - barrier);
+    // ...minus a put option struck at B.
+    auto lowerPayoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, barrier);
+    auto put2 = ext::make_shared<EuropeanOption>(lowerPayoff, exercise);
+    put2->setPricingEngine(europeanEngine);
+    portfolio.subtract(put2);
+
+    // Now we use puts struck at B to kill the value of the
+    // portfolio on a number of points (B,t).
+
+    Integer i;
+    for (i = B * t; i >= t; i -= t) {
+        Date innerMaturity = today + i * timeUnit;
+        auto innerExercise = ext::make_shared<EuropeanExercise>(innerMaturity);
+        auto innerPayoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, barrier);
+        auto putn = ext::make_shared<EuropeanOption>(innerPayoff, innerExercise);
+        putn->setPricingEngine(europeanEngine);
+        // ...second, we evaluate the current portfolio and the
+        // latest put at (B,t)...
+        Date killDate = today + (i - t) * timeUnit;
+        Settings::instance().evaluationDate() = killDate;
+        underlyingH->setValue(barrier);
+        Real portfolioValue = portfolio.NPV();
+        Real putValue = putn->NPV();
+        // ...finally, we estimate the notional that kills the
+        // portfolio value at that point...
+        Real notional = portfolioValue / putValue;
+        // ...and we subtract from the portfolio a put with such
+        // notional.
+        portfolio.subtract(putn, notional);
+    }
+    Settings::instance().evaluationDate() = today;
+    underlyingH->setValue(underlying);
+    // ...and output the value.
+    Real portfolioValue = portfolio.NPV();
+    return portfolioValue;
+}
+
+
+#ifndef QLXAD_DISABLE_AAD
+
+// create tape
+using tape_type = Real::tape_type;
+tape_type tape;
+
+
+Real priceWithSensi(const std::vector<Date>& dates,
+                    const std::vector<Real>& riskFreeRates,
+                    const DayCounter& dayCounter,
+                    Date maturity,
+                    Real strike,
+                    Option::Type type,
+                    Barrier::Type barrierType,
+                    Real underlying,
+                    Real v,
+                    Real barrier,
+                    Real rebate,
+                    Integer B,
+                    Integer t,
+                    TimeUnit timeUnit,
+                    Date today,
+                    std::vector<Real>& gradient) {
+    tape.clearAll();
+
+    auto riskFreeRates_t = riskFreeRates;
+
+    tape.registerInputs(riskFreeRates_t);
+    tape.registerInput(strike);
+    tape.registerInput(v);
+    tape.registerInput(underlying);
+    tape.registerInput(barrier);
+    tape.newRecording();
+
+    Real value = pricePortfolio(dates, riskFreeRates_t, dayCounter, maturity, strike, type,
+                                barrierType, underlying, v, barrier, rebate, B, t, timeUnit, today);
+
+    // get the values
+    tape.registerOutput(value);
+    derivative(value) = 1.0;
+    tape.computeAdjoints();
+
+    gradient.clear();
+    for (std::size_t i = 0; i < riskFreeRates_t.size(); ++i) {
+        gradient.push_back(derivative(riskFreeRates_t[i]));
+    }
+    gradient.push_back(derivative(strike));
+    gradient.push_back(derivative(v));
+    gradient.push_back(derivative(underlying));
+    gradient.push_back(derivative(barrier));
+
+    return value;
+}
+
+
+#else
+
+Real priceWithSensi(const std::vector<Date>& dates,
+                    const std::vector<Real>& riskFreeRates,
+                    const DayCounter& dayCounter,
+                    Date maturity,
+                    Real strike,
+                    Option::Type type,
+                    Barrier::Type barrierType,
+                    Real underlying,
+                    Real v,
+                    Real barrier,
+                    Real rebate,
+                    Integer B,
+                    Integer t,
+                    TimeUnit timeUnit,
+                    Date today,
+                    std::vector<Real>& gradient) {
+
+    Real value = pricePortfolio(dates, riskFreeRates, dayCounter, maturity, strike, type,
+                                barrierType, underlying, v, barrier, rebate, B, t, timeUnit, today);
+
+    Real eps = 1e-5;
+    gradient.clear();
+    auto riskFreeRates_t = riskFreeRates;
+    for (std::size_t i = 0; i < riskFreeRates_t.size(); ++i) {
+        riskFreeRates_t[i] += eps;
+        Real v1 =
+            pricePortfolio(dates, riskFreeRates_t, dayCounter, maturity, strike, type, barrierType,
+                           underlying, v, barrier, rebate, B, t, timeUnit, today);
+        gradient.push_back((v1 - value) / eps);
+        riskFreeRates_t[i] -= eps;
+    }
+
+    Real v1 = pricePortfolio(dates, riskFreeRates, dayCounter, maturity, strike + eps, type,
+                             barrierType, underlying, v, barrier, rebate, B, t, timeUnit, today);
+    gradient.push_back((v1 - value) / eps);
+
+    v1 = pricePortfolio(dates, riskFreeRates, dayCounter, maturity, strike, type, barrierType,
+                        underlying, v + eps, barrier, rebate, B, t, timeUnit, today);
+    gradient.push_back((v1 - value) / eps);
+
+    v1 = pricePortfolio(dates, riskFreeRates, dayCounter, maturity, strike, type, barrierType,
+                        underlying + eps, v, barrier, rebate, B, t, timeUnit, today);
+    gradient.push_back((v1 - value) / eps);
+
+
+    v1 = pricePortfolio(dates, riskFreeRates, dayCounter, maturity, strike, type, barrierType,
+                        underlying, v, barrier + eps, rebate, B, t, timeUnit, today);
+    gradient.push_back((v1 - value) / eps);
+
+    return value;
+}
+
+#endif
+
+void printResults(Real v, const std::vector<Real>& gradient, Size nRates) {
+    std::cout << "Value              = " << v << "\n";
+    std::cout << "Rho                = [";
+    for (Size i = 0; i < nRates; ++i) {
+        std::cout << gradient[i] << ", ";
+    }
+    std::cout << "]\n";
+    std::cout << "Strike Sensitivity = " << gradient[nRates] << "\n";
+    std::cout << "Vega               = " << gradient[nRates + 1] << "\n";
+    std::cout << "Delta              = " << gradient[nRates + 2] << "\n";
+    std::cout << "Barrier            = " << gradient[nRates + 3] << "\n";
+}
+
+int main() {
+    try {
+        std::cout << std::endl;
+
+        Date today(29, May, 2006);
+        Settings::instance().evaluationDate() = today;
+
+        // the option to replicate
+        Barrier::Type barrierType = Barrier::DownOut;
+        Real barrier = 70.0;
+        Real rebate = 0.0;
+        Option::Type type = Option::Put;
+        Real underlying = 100.0;
+
+        Real strike = 101.0;
+        Real v = 0.20;
+
+        Date maturity = today + 1 * Years;
+
+        DayCounter dayCounter = Actual365Fixed();
+
+
+        std::vector<Integer> tn = {13, 41, 75, 165, 256, 345, 524, 703};
+        std::vector<Rate> rates = {0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04};
+
+
+        std::vector<Date> dates;
+        dates.push_back(today);
+        Size i;
+        for (i = 0; i < 8; ++i) {
+            dates.push_back(today + tn[i]);
+        }
+
+        std::cout.precision(15);
+
+        // pricing a barrier option base barrier option
+        std::cout << "Pricing barrier option...\n";
+        Real value = priceBarrierOption(dates, rates, dayCounter, maturity, strike, type,
+                                        barrierType, underlying, v, barrier, rebate);
+
+        std::cout << "Original barrier option value : " << value << "\n";
+
+        // pricing a portfolio of a barrier option without AAD
+        int B = 26;                // number of dates
+        int t = 2;                 // number of the repetition of time unit
+        TimeUnit timeUnit = Weeks; // type of time unit
+
+        constexpr int N = 1000;
+
+        std::cout << "Pricing replication portfolio without sensitivities...\n";
+        Real v1 = 0.0;
+        auto start = std::chrono::high_resolution_clock::now();
+        for (int i = 0; i < N; ++i) {
+            v1 = pricePortfolio(dates, rates, dayCounter, maturity, strike, type, barrierType,
+                                underlying, v, barrier, rebate, B, t, timeUnit, today);
+        }
+        auto end = std::chrono::high_resolution_clock::now();
+        auto time_plain =
+            static_cast<double>(
+                std::chrono::duration_cast<std::chrono::microseconds>(end - start).count()) *
+            1e-3 / N;
+
+        std::cout << "Value = " << v1 << "\n";
+
+        // pricing with AADs
+        std::vector<Real> gradient;
+        std::cout << "Pricing replication portfolio with sensitivities...\n";
+        Real v2 = 0.0;
+        start = std::chrono::high_resolution_clock::now();
+        for (int i = 0; i < N; ++i) {
+            v2 = priceWithSensi(dates, rates, dayCounter, maturity, strike, type, barrierType,
+                                underlying, v, barrier, rebate, B, t, timeUnit, today, gradient);
+        }
+        end = std::chrono::high_resolution_clock::now();
+        auto time_sensi =
+            static_cast<double>(
+                std::chrono::duration_cast<std::chrono::microseconds>(end - start).count()) *
+            1e-3 / N;
+
+        printResults(v2, gradient, rates.size());
+
+
+        std::cout << "Plain time : " << time_plain << "ms\n"
+                  << "Sensi time : " << time_sensi << "ms\n"
+                  << "Factor     : " << time_sensi / time_plain << "x\n";
+
+        return 0;
+    } catch (std::exception& e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    } catch (...) {
+        std::cerr << "unknown error" << std::endl;
+        return 1;
+    }
+}

--- a/Examples/AdjointReplication/CMakeLists.txt
+++ b/Examples/AdjointReplication/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(AdjointReplication AdjointReplicationXAD.cpp)
+target_link_libraries(AdjointReplication ql_library)
+if(QL_INSTALL_EXAMPLES)
+    install(TARGETS AdjointReplication RUNTIME DESTINATION  ${QL_INSTALL_EXAMPLESDIR})
+endif()

--- a/Examples/AdjointSwap/AdjointSwapXAD.cpp
+++ b/Examples/AdjointSwap/AdjointSwapXAD.cpp
@@ -250,7 +250,7 @@ double priceWithSensi(const std::vector<double>& marketQuotes,
     Real v = pricePortfolio(curveHandle, portfolio);
 
     Real eps = 1e-5;
-    for (int i = 0; i < marketQuotesCpy.size(); ++i) {
+    for (Size i = 0; i < marketQuotesCpy.size(); ++i) {
         marketQuotesCpy[i] += eps;
         auto curveHandle =
             bootstrapCurve(Settings::instance().evaluationDate(), marketQuotesCpy, maxMaturity);

--- a/Examples/AdjointSwap/AdjointSwapXAD.cpp
+++ b/Examples/AdjointSwap/AdjointSwapXAD.cpp
@@ -1,7 +1,7 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*
- Copyright (C) 2022 Xcelerit
+ Copyright (C) 2022, 2023 Xcelerit
 
  This file is part of QuantLib / XAD integration module.
  It is modified from QuantLib, a free-software/open-source library
@@ -18,20 +18,31 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
+/*
+This example shows how to calculate sensitivities to market quotes for
+pricing a portfolio of swaps using XAD.
+It also measures the performance for calculating sensitivities,
+either with XAD or with plain doubles and bumping (when QLXAD_DISABLE_AAD is ON).
+*/
 
-#include <ql/quotes/simplequote.hpp>
+
+#include <ql/qldefines.hpp>
+#if !defined(BOOST_ALL_NO_LIB) && defined(BOOST_MSVC)
+#    include <ql/auto_link.hpp>
+#endif
 #include <ql/indexes/ibor/euribor.hpp>
+#include <ql/math/randomnumbers/mt19937uniformrng.hpp>
+#include <ql/pricingengines/swap/discountingswapengine.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/termstructures/iterativebootstrap.hpp>
+#include <ql/termstructures/yield/bootstraptraits.hpp>
+#include <ql/termstructures/yield/piecewiseyieldcurve.hpp>
+#include <ql/termstructures/yield/ratehelpers.hpp>
+#include <ql/termstructures/yieldtermstructure.hpp>
 #include <ql/time/calendars/target.hpp>
 #include <ql/time/daycounters/actual360.hpp>
 #include <ql/time/daycounters/thirty360.hpp>
-#include <ql/termstructures/yieldtermstructure.hpp>
-#include <ql/termstructures/yield/ratehelpers.hpp>
-#include <ql/termstructures/yield/bootstraptraits.hpp>
-#include <ql/termstructures/iterativebootstrap.hpp>
-#include <ql/termstructures/yield/piecewiseyieldcurve.hpp>
-#include <ql/math/randomnumbers/mt19937uniformrng.hpp>
-#include <ql/pricingengines/swap/discountingswapengine.hpp>
-
+#include <XAD/XAD.hpp>
 #include <chrono>
 #include <vector>
 
@@ -44,10 +55,10 @@ const int Nfra = 5;
 void prepareQuotes(Size maximumMaturity, std::vector<double>& marketQuotes) {
     // setting up market quotes
     // deposit quotes on, tn, sn, sw, 1m, ... , 6m
-    for (Size i = 0; i < Ndepos; ++i) 
+    for (Size i = 0; i < Ndepos; ++i)
         marketQuotes.push_back(0.0010 + i * 0.0002);
     // fra quotes 1-7, ... , 5-11
-    for (Size i = 0; i < Nfra; ++i) 
+    for (Size i = 0; i < Nfra; ++i)
         marketQuotes.push_back(0.0030 + i * 0.0005);
     // swap quotes 1y, ... , maximum maturity
     for (Size i = 0; i < maximumMaturity; ++i)
@@ -55,8 +66,8 @@ void prepareQuotes(Size maximumMaturity, std::vector<double>& marketQuotes) {
 }
 
 // bootstraps the curve used for the swaps
-Handle<YieldTermStructure> bootstrapCurve(Date referenceDate, const std::vector<Real>& marketQuotes,
-                                          Size maximumMaturity) {
+Handle<YieldTermStructure>
+bootstrapCurve(Date referenceDate, const std::vector<Real>& marketQuotes, Size maximumMaturity) {
     // build quotes
     std::vector<boost::shared_ptr<SimpleQuote>> quotes;
     std::transform(marketQuotes.begin(), marketQuotes.end(), std::back_inserter(quotes),
@@ -113,11 +124,13 @@ Handle<YieldTermStructure> bootstrapCurve(Date referenceDate, const std::vector<
 
     // build a piecewise yield curve
     using CurveType = PiecewiseYieldCurve<ZeroYield, Linear, IterativeBootstrap>;
-    return Handle<YieldTermStructure>(boost::make_shared<CurveType>(referenceDate, instruments, Actual365Fixed()));
+    return Handle<YieldTermStructure>(
+        boost::make_shared<CurveType>(referenceDate, instruments, Actual365Fixed()));
 }
 
 // creates the Swap portfolio, given the curve
-std::vector<boost::shared_ptr<VanillaSwap>> setupPortfolio(Size portfolioSize, Size maximumMaturity, Handle<YieldTermStructure> curveHandle) {
+std::vector<boost::shared_ptr<VanillaSwap>>
+setupPortfolio(Size portfolioSize, Size maximumMaturity, Handle<YieldTermStructure> curveHandle) {
     auto euribor6mYts = boost::make_shared<Euribor>(6 * Months, curveHandle);
 
     // set up a vanilla swap portfolio
@@ -132,7 +145,8 @@ std::vector<boost::shared_ptr<VanillaSwap>> setupPortfolio(Size portfolioSize, S
         Real fixedRate = mt.nextReal() * 0.10;
         Date effective(6, October, 2014);
         Date termination = TARGET().advance(
-            effective, static_cast<Size>(mt.nextReal() * static_cast<double>(maximumMaturity) + 1.) * Years);
+            effective,
+            static_cast<Size>(mt.nextReal() * static_cast<double>(maximumMaturity) + 1.) * Years);
 
         Schedule fixedSchedule(effective, termination, 1 * Years, TARGET(), ModifiedFollowing,
                                Following, DateGeneration::Backward, false);
@@ -154,7 +168,7 @@ Real pricePortfolio(Handle<YieldTermStructure> curveHandle,
 
     auto pricingEngine = boost::make_shared<DiscountingSwapEngine>(curveHandle);
     Real y = 0.0;
-    for (auto& swap: portfolio) {
+    for (auto& swap : portfolio) {
         swap->setPricingEngine(pricingEngine);
         y += swap->NPV();
     }
@@ -178,13 +192,17 @@ Real pricePlain(const std::vector<double>& marketQuotes, Size portfolioSize, Siz
     return v;
 }
 
+#ifndef QLXAD_DISABLE_AAD
 
 // create tape
 using tape_type = Real::tape_type;
 tape_type tape;
 
 // price with sensitivities using AAD
-double priceWithSensi(const std::vector<double>& marketQuotes,  Size portfolioSize, Size maxMaturity, std::vector<double>& gradient) {
+double priceWithSensi(const std::vector<double>& marketQuotes,
+                      Size portfolioSize,
+                      Size maxMaturity,
+                      std::vector<double>& gradient) {
 
     tape.clearAll();
     gradient.clear();
@@ -193,7 +211,7 @@ double priceWithSensi(const std::vector<double>& marketQuotes,  Size portfolioSi
     std::vector<Real> marketQuotesAD(marketQuotes.begin(), marketQuotes.end());
 
     // register independent variables with the tape as inputs and start a new recording
-    tape.registerInputs(marketQuotesAD);  
+    tape.registerInputs(marketQuotesAD);
     tape.newRecording();
 
     // build curve and price
@@ -213,10 +231,42 @@ double priceWithSensi(const std::vector<double>& marketQuotes,  Size portfolioSi
     return value(v);
 }
 
+#else
+
+// price with sensitivities using Bumping
+double priceWithSensi(const std::vector<double>& marketQuotes,
+                      Size portfolioSize,
+                      Size maxMaturity,
+                      std::vector<double>& gradient) {
+    gradient.clear();
+
+    // convert double market quotes into AD type (Real is active double type)
+    std::vector<Real> marketQuotesCpy(marketQuotes.begin(), marketQuotes.end());
+
+    // build curve and price
+    auto curveHandle =
+        bootstrapCurve(Settings::instance().evaluationDate(), marketQuotesCpy, maxMaturity);
+    auto portfolio = setupPortfolio(portfolioSize, maxMaturity, curveHandle);
+    Real v = pricePortfolio(curveHandle, portfolio);
+
+    Real eps = 1e-5;
+    for (int i = 0; i < marketQuotesCpy.size(); ++i) {
+        marketQuotesCpy[i] += eps;
+        auto curveHandle =
+            bootstrapCurve(Settings::instance().evaluationDate(), marketQuotesCpy, maxMaturity);
+        auto portfolio = setupPortfolio(portfolioSize, maxMaturity, curveHandle);
+        Real v1 = pricePortfolio(curveHandle, portfolio);
+        gradient.push_back(xad::value((v - v1) / eps));
+        marketQuotesCpy[i] -= eps;
+    }
+
+    return xad::value(v);
+}
+
+
+#endif
 
 void printResults(double v, const std::vector<double>& gradient) {
-    std::cout << "--------- Pricing with AAD ------------\n\n";
-
     std::cout.precision(2);
     std::cout << std::fixed;
     std::cout.imbue(std::locale(""));
@@ -237,43 +287,55 @@ void printResults(double v, const std::vector<double>& gradient) {
 }
 
 int main() {
-    
-    Size portfolioSize = 50;
-    Size maxMaturity = 40;
+    try {
+        Size portfolioSize = 50;
+        Size maxMaturity = 40;
 
-    // market Quotes
-    std::vector<double> marketQuotes;
-    prepareQuotes(maxMaturity, marketQuotes);
+        // market Quotes
+        std::vector<double> marketQuotes;
+        prepareQuotes(maxMaturity, marketQuotes);
 
-    // evaluation date
-    Date referenceDate(2, January, 2015);
-    Settings::instance().evaluationDate() = referenceDate;
+        // evaluation date
+        Date referenceDate(2, January, 2015);
+        Settings::instance().evaluationDate() = referenceDate;
 
-    constexpr int N = 20;
-    std::cout << "Pricing portfolio of " << portfolioSize << " swaps...\n";
-    auto start = std::chrono::high_resolution_clock::now();
-    Real v = 0.0;
-    for (int i = 0; i < N; ++i) v = pricePlain(marketQuotes, portfolioSize, maxMaturity);
-    auto end = std::chrono::high_resolution_clock::now();
-    auto time_plain = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count()) / N * 1e-3;
-    std::cout << "portfolio Value: " << v << "\n";
-    
-    std::vector<double> gradient;
+        constexpr int N = 20;
+        std::cout << "Pricing portfolio of " << portfolioSize << " swaps...\n";
+        auto start = std::chrono::high_resolution_clock::now();
+        Real v = 0.0;
+        for (int i = 0; i < N; ++i)
+            v = pricePlain(marketQuotes, portfolioSize, maxMaturity);
+        auto end = std::chrono::high_resolution_clock::now();
+        auto time_plain =
+            static_cast<double>(
+                std::chrono::duration_cast<std::chrono::microseconds>(end - start).count()) *
+            1e-3 / N;
+        std::cout << "portfolio Value: " << v << "\n";
 
-    std::cout << "Pricing portfolio of " << portfolioSize << " swaps with sensitivities...\n";
-    start = std::chrono::high_resolution_clock::now();
-    double v2 = 0.0;
-    for (int i = 0; i < N; ++i)
-        v2 = priceWithSensi(marketQuotes, portfolioSize, maxMaturity, gradient);
-    end = std::chrono::high_resolution_clock::now();
-    auto time_sensi = static_cast<double>(
-                    std::chrono::duration_cast<std::chrono::microseconds>(end - start).count()) /
-                N * 1e-3;
-    std::cout << "portfolio Value: " << v2 << "\n";
+        std::vector<double> gradient;
 
-    printResults(v2, gradient);
+        std::cout << "Pricing portfolio of " << portfolioSize << " swaps with sensitivities...\n";
+        start = std::chrono::high_resolution_clock::now();
+        double v2 = 0.0;
+        for (int i = 0; i < N; ++i)
+            v2 = priceWithSensi(marketQuotes, portfolioSize, maxMaturity, gradient);
+        end = std::chrono::high_resolution_clock::now();
+        auto time_sensi =
+            static_cast<double>(
+                std::chrono::duration_cast<std::chrono::microseconds>(end - start).count()) *
+            1e-3 / N;
 
-    std::cout << "Plain time : " << time_plain << "ms\n"
-              << "Sensi time : " << time_sensi << "ms\n"
-              << "Factor     : " << time_sensi/time_plain << "x\n";
+        printResults(v2, gradient);
+
+        std::cout << "Plain time : " << time_plain << "ms\n"
+                  << "Sensi time : " << time_sensi << "ms\n"
+                  << "Factor     : " << time_sensi / time_plain << "x\n";
+        return 0;
+    } catch (std::exception& e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    } catch (...) {
+        std::cerr << "unknown error" << std::endl;
+        return 1;
+    }
 }

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -1,2 +1,10 @@
-add_subdirectory(AdjointSwap)
+add_subdirectory(AdjointAmericanEquityOption)
 add_subdirectory(AdjointBermudanSwaption)
+add_subdirectory(AdjointCDS)
+add_subdirectory(AdjointEuropeanEquityOption)
+add_subdirectory(AdjointHestonModel)
+add_subdirectory(AdjointMulticurveBootstrapping)
+add_subdirectory(AdjointSwap)
+add_subdirectory(AdjointReplication)
+
+

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -5,7 +5,7 @@
 #  QuantLib. XAD is a fast and comprehensive C++ library for
 #  automatic differentiation.
 #
-#  Copyright (C) 2010-2022 Xcelerit Computing Ltd.
+#  Copyright (C) 2010-2023 Xcelerit Computing Ltd.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU Affero General Public License as published
@@ -30,7 +30,11 @@ target_include_directories(qlxad INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
     $<INSTALL_INTERFACE:${QL_INSTALL_INCLUDEDIR}>
 )
-target_compile_definitions(qlxad INTERFACE QL_INCLUDE_FIRST=ql/qlxad.hpp)
+if(NOT QLXAD_DISABLE_AAD)
+    target_compile_definitions(qlxad INTERFACE QL_INCLUDE_FIRST=ql/qlxad.hpp)
+else()
+    target_compile_definitions(qlxad INTERFACE QLXAD_DISABLE_AAD=1)
+endif()
 if(MSVC)
     target_compile_options(qlxad INTERFACE /bigobj)
 endif()

--- a/ql/qlxad.hpp
+++ b/ql/qlxad.hpp
@@ -4,7 +4,7 @@
    QuantLib. XAD is a fast and comprehensive C++ library for
    automatic differentiation.
 
-   Copyright (C) 2010-2022 Xcelerit Computing Ltd.
+   Copyright (C) 2010-2023 Xcelerit Computing Ltd.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU Affero General Public License as published
@@ -485,4 +485,3 @@ namespace std {
 #include <random>
 
 #endif
-

--- a/test-suite/CMakeLists.txt
+++ b/test-suite/CMakeLists.txt
@@ -1,14 +1,30 @@
 set(QLXAD_TEST_SOURCES
     americanoption_xad.cpp
+    europeanoption_xad.cpp
+    barrieroption_xad.cpp
+    forwardrateagreement_xad.cpp
     batesmodel_xad.cpp
+    swap_xad.cpp
     quantlibtestsuite_xad.cpp
     utilities_xad.cpp
+    creditdefaultswap_xad.cpp
+    bonds_xad.cpp
+    bermudanswaption_xad.cpp
+    hestonmodel_xad.cpp
 )
 
 set(QLXAD_TEST_HEADERS
     americanoption_xad.hpp
+    europeanoption_xad.hpp
+    barrieroption_xad.hpp
+    forwardrateagreement_xad.hpp
     batesmodel_xad.hpp
+    swap_xad.hpp
     utilities_xad.hpp
+    bonds_xad.hpp
+    creditdefaultswap_xad.cpp
+    bermudanswaption_xad.hpp
+    hestonmodel_xad.hpp
 )
 
 if(QL_BUILD_TEST_SUITE)

--- a/test-suite/americanoption_xad.cpp
+++ b/test-suite/americanoption_xad.cpp
@@ -4,7 +4,7 @@
  Copyright (C) 2003, 2004 Ferdinando Ametrano
  Copyright (C) 2005, 2007 StatPro Italia srl
  Copyright (C) 2005 Joseph Wang
- Copyright (C) 2022 Xcelerit
+ Copyright (C) 2023 Xcelerit
 
  This file is part of QuantLib / XAD integration module.
  It is modified from QuantLib, a free-software/open-source library
@@ -132,29 +132,28 @@ namespace {
     Real priceBaroneAdesiWhaley(const AmericanOptionData& value) {
         Date today = Date::todaysDate();
         DayCounter dc = Actual360();
-        ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-        ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+        auto spot = ext::make_shared<SimpleQuote>(0.0);
+        auto qRate = ext::make_shared<SimpleQuote>(0.0);
         ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-        ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+        auto rRate = ext::make_shared<SimpleQuote>(0.0);
         ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-        ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+        auto vol = ext::make_shared<SimpleQuote>(0.0);
         ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(value.type, value.strike));
+        auto payoff = ext::make_shared<PlainVanillaPayoff>(value.type, value.strike);
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new AmericanExercise(today, exDate));
+        auto exercise = ext::make_shared<AmericanExercise>(today, exDate);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new BlackScholesMertonProcess(
+        auto stochProcess = ext::make_shared<BlackScholesMertonProcess>(
             Handle<Quote>(spot), Handle<YieldTermStructure>(qTS), Handle<YieldTermStructure>(rTS),
-            Handle<BlackVolTermStructure>(volTS)));
+            Handle<BlackVolTermStructure>(volTS));
 
-        ext::shared_ptr<PricingEngine> engine(
-            new BaroneAdesiWhaleyApproximationEngine(stochProcess));
+        auto engine = ext::make_shared<BaroneAdesiWhaleyApproximationEngine>(stochProcess);
 
         VanillaOption option(payoff, exercise);
         option.setPricingEngine(engine);
@@ -194,29 +193,28 @@ namespace {
     Real priceBjerksundStensland(const AmericanOptionData& value) {
         Date today = Date::todaysDate();
         DayCounter dc = Actual360();
-        ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-        ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+        auto spot = ext::make_shared<SimpleQuote>(0.0);
+        auto qRate = ext::make_shared<SimpleQuote>(0.0);
         ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-        ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+        auto rRate = ext::make_shared<SimpleQuote>(0.0);
         ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-        ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+        auto vol = ext::make_shared<SimpleQuote>(0.0);
         ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(value.type, value.strike));
+        auto payoff = ext::make_shared<PlainVanillaPayoff>(value.type, value.strike);
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new AmericanExercise(today, exDate));
+        auto exercise = ext::make_shared<AmericanExercise>(today, exDate);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new BlackScholesMertonProcess(
+        auto stochProcess = ext::make_shared<BlackScholesMertonProcess>(
             Handle<Quote>(spot), Handle<YieldTermStructure>(qTS), Handle<YieldTermStructure>(rTS),
-            Handle<BlackVolTermStructure>(volTS)));
+            Handle<BlackVolTermStructure>(volTS));
 
-        ext::shared_ptr<PricingEngine> engine(
-            new BjerksundStenslandApproximationEngine(stochProcess));
+        auto engine = ext::make_shared<BjerksundStenslandApproximationEngine>(stochProcess);
 
         VanillaOption option(payoff, exercise);
         option.setPricingEngine(engine);
@@ -256,29 +254,28 @@ namespace {
     Real priceJu(const AmericanOptionData& juValue) {
         Date today = Date::todaysDate();
         DayCounter dc = Actual360();
-        ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-        ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+        auto spot = ext::make_shared<SimpleQuote>(0.0);
+        auto qRate = ext::make_shared<SimpleQuote>(0.0);
         ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-        ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+        auto rRate = ext::make_shared<SimpleQuote>(0.0);
         ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-        ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+        auto vol = ext::make_shared<SimpleQuote>(0.0);
         ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-            new PlainVanillaPayoff(juValue.type, juValue.strike));
+        auto payoff = ext::make_shared<PlainVanillaPayoff>(juValue.type, juValue.strike);
         Date exDate = today + timeToDays(juValue.t);
-        ext::shared_ptr<Exercise> exercise(new AmericanExercise(today, exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<AmericanExercise>(today, exDate);
 
         spot->setValue(juValue.s);
         qRate->setValue(juValue.q);
         rRate->setValue(juValue.r);
         vol->setValue(juValue.v);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new BlackScholesMertonProcess(
+        auto stochProcess = ext::make_shared<BlackScholesMertonProcess>(
             Handle<Quote>(spot), Handle<YieldTermStructure>(qTS), Handle<YieldTermStructure>(rTS),
-            Handle<BlackVolTermStructure>(volTS)));
+            Handle<BlackVolTermStructure>(volTS));
 
-        ext::shared_ptr<PricingEngine> engine(new JuQuadraticApproximationEngine(stochProcess));
+        auto engine = ext::make_shared<JuQuadraticApproximationEngine>(stochProcess);
 
         VanillaOption option(payoff, exercise);
         option.setPricingEngine(engine);
@@ -315,19 +312,18 @@ namespace {
     Real priceFd(const AmericanOptionData& juValue) {
         Date today = Date::todaysDate();
         DayCounter dc = Actual360();
-        ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-        ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+        auto spot = ext::make_shared<SimpleQuote>(0.0);
+        auto qRate = ext::make_shared<SimpleQuote>(0.0);
         ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-        ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+        auto rRate = ext::make_shared<SimpleQuote>(0.0);
         ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-        ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+        auto vol = ext::make_shared<SimpleQuote>(0.0);
         ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-            new PlainVanillaPayoff(juValue.type, juValue.strike));
+        auto payoff = ext::make_shared<PlainVanillaPayoff>(juValue.type, juValue.strike);
 
         Date exDate = today + timeToDays(juValue.t);
-        ext::shared_ptr<Exercise> exercise(new AmericanExercise(today, exDate));
+        auto exercise = ext::make_shared<AmericanExercise>(today, exDate);
 
         spot->setValue(juValue.s);
         qRate->setValue(juValue.q);

--- a/test-suite/barrieroption_xad.cpp
+++ b/test-suite/barrieroption_xad.cpp
@@ -1,0 +1,199 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2003, 2004 Ferdinando Ametrano
+ Copyright (C) 2005, 2007 StatPro Italia srl
+ Copyright (C) 2005 Joseph Wang
+ Copyright (C) 2023 Xcelerit
+
+ This file is part of QuantLib / XAD integration module.
+ It is modified from QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "barrieroption_xad.hpp"
+#include "utilities_xad.hpp"
+#include <ql/instruments/barrieroption.hpp>
+#include <ql/pricingengines/barrier/analyticbarrierengine.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/termstructures/volatility/equityfx/blackconstantvol.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/time/calendars/nullcalendar.hpp>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+namespace {
+
+    struct BarrierOptionData {
+        Option::Type type;
+        Real strike;
+        Real u;       // underlying
+        Rate r;       // risk-free rate
+        Real b;       // barrier
+        Volatility v; // volatility
+    };
+
+}
+namespace {
+
+    template <class PriceFunc>
+    Real priceWithBumping(const BarrierOptionData& value,
+                          BarrierOptionData& derivatives,
+                          PriceFunc func) {
+        // Bumping
+        auto eps = 1e-7;
+        auto data = value;
+        auto v = func(data);
+
+        data.strike += eps;
+        auto vplus = func(data);
+        derivatives.strike = (vplus - v) / eps;
+        data = value;
+
+        data.u += eps;
+        vplus = func(data);
+        derivatives.u = (vplus - v) / eps;
+        data = value;
+
+        data.r += eps;
+        vplus = func(data);
+        derivatives.r = (vplus - v) / eps;
+        data = value;
+
+        data.b += eps;
+        vplus = func(data);
+        derivatives.b = (vplus - v) / eps;
+        data = value;
+
+        data.v += eps;
+        vplus = func(data);
+        derivatives.v = (vplus - v) / eps;
+
+        return v;
+    }
+
+    template <class PriceFunc>
+    Real
+    priceWithAAD(const BarrierOptionData& values, BarrierOptionData& derivatives, PriceFunc func) {
+        // AAD
+        using tape_type = Real::tape_type;
+        tape_type tape;
+        auto data = values;
+        tape.registerInput(data.strike);
+        tape.registerInput(data.u);
+        tape.registerInput(data.r);
+        tape.registerInput(data.b);
+        tape.registerInput(data.v);
+        tape.newRecording();
+
+        auto price = func(data);
+
+        tape.registerOutput(price);
+        derivative(price) = 1.0;
+        tape.computeAdjoints();
+
+        derivatives.strike = derivative(data.strike);
+        derivatives.u = derivative(data.u);
+        derivatives.r = derivative(data.r);
+        derivatives.b = derivative(data.u);
+        derivatives.v = derivative(data.b);
+
+        return price;
+    }
+}
+
+namespace {
+    Real priceBarrierOption(const BarrierOptionData& value) {
+        std::cout << std::endl;
+
+        Date today(29, May, 2006);
+        Settings::instance().evaluationDate() = today;
+
+        // the option to replicate
+        Barrier::Type barrierType = Barrier::DownOut;
+        Real barrier = 70.0;
+        Real rebate = 0.0;
+        Option::Type type = Option::Put;
+        Real underlying = 100.0;
+        auto underlyingH = ext::make_shared<SimpleQuote>(underlying);
+        Real strike = 100.0;
+        Real r = 0.04;
+        Real v = 0.20;
+        auto riskFreeRate = ext::make_shared<SimpleQuote>(r);
+        auto volatility = ext::make_shared<SimpleQuote>(v);
+        Date maturity = today + 1 * Years;
+
+        DayCounter dayCounter = Actual365Fixed();
+
+        Handle<Quote> h1(riskFreeRate);
+        Handle<Quote> h2(volatility);
+        Handle<YieldTermStructure> flatRate(
+            ext::make_shared<FlatForward>(0, NullCalendar(), h1, dayCounter));
+        Handle<BlackVolTermStructure> flatVol(
+            ext::make_shared<BlackConstantVol>(0, NullCalendar(), h2, dayCounter));
+
+        // instantiate the option
+        auto exercise = ext::make_shared<EuropeanExercise>(maturity);
+        auto payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
+
+        auto bsProcess =
+            ext::make_shared<BlackScholesProcess>(Handle<Quote>(underlyingH), flatRate, flatVol);
+
+
+        /// option
+        auto referenceOption =
+            ext::make_shared<BarrierOption>(barrierType, barrier, rebate, payoff, exercise);
+
+        referenceOption->setPricingEngine(ext::make_shared<AnalyticBarrierEngine>(bsProcess));
+
+        return referenceOption->NPV();
+    }
+}
+
+void BarrierOptionXadTest::testBarrierOptionDerivatives() {
+
+    SavedSettings save;
+    BOOST_TEST_MESSAGE("Testing barrier options derivatives...");
+
+    // input
+    auto data = BarrierOptionData{Option::Call, 100.00, 90.00, 0.10, 0.10, 0.10};
+
+    // bumping
+    auto derivatives_bumping = BarrierOptionData{};
+    auto expected = priceWithBumping(data, derivatives_bumping, priceBarrierOption);
+
+    // aad
+    auto derivatives_aad = BarrierOptionData{};
+    auto actual = priceWithAAD(data, derivatives_aad, priceBarrierOption);
+
+    // compare
+    QL_CHECK_CLOSE(expected, actual, 1e-9);
+    QL_CHECK_CLOSE(derivatives_bumping.strike, derivatives_aad.strike, 1e-7);
+    QL_CHECK_CLOSE(derivatives_bumping.u, derivatives_aad.u, 1e-7);
+    QL_CHECK_CLOSE(derivatives_bumping.r, derivatives_aad.r, 1e-7);
+    QL_CHECK_CLOSE(derivatives_bumping.b, derivatives_aad.b, 1e-7);
+    QL_CHECK_CLOSE(derivatives_bumping.v, derivatives_aad.v, 1e-7);
+}
+
+test_suite* BarrierOptionXadTest::suite() {
+    auto* suite = BOOST_TEST_SUITE("barrier option derivatives tests");
+
+    suite->add(QLXAD_TEST_CASE(&BarrierOptionXadTest::testBarrierOptionDerivatives));
+
+    return suite;
+}

--- a/test-suite/barrieroption_xad.hpp
+++ b/test-suite/barrieroption_xad.hpp
@@ -1,8 +1,10 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*
- Copyright (C) 2005 Klaus Spanderen
- Copyright (C) 2022 Xcelerit
+ Copyright (C) 2003, 2004 Ferdinando Ametrano
+ Copyright (C) 2005, 2007 StatPro Italia srl
+ Copyright (C) 2005 Joseph Wang
+ Copyright (C) 2023 Xcelerit
 
  This file is part of QuantLib / XAD integration module.
  It is modified from QuantLib, a free-software/open-source library
@@ -23,8 +25,8 @@
 
 #include <boost/test/unit_test.hpp>
 
-class BatesModelXadTest {
+class BarrierOptionXadTest {
   public:
-    static void testBatesModelDerivatives();
+    static void testBarrierOptionDerivatives();
     static boost::unit_test_framework::test_suite* suite();
 };

--- a/test-suite/bermudanswaption_xad.cpp
+++ b/test-suite/bermudanswaption_xad.cpp
@@ -1,0 +1,199 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2003, 2004 Ferdinando Ametrano
+ Copyright (C) 2005, 2007 StatPro Italia srl
+ Copyright (C) 2005 Joseph Wang
+ Copyright (C) 2023 Xcelerit
+
+ This file is part of QuantLib / XAD integration module.
+ It is modified from QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "bermudanswaption_xad.hpp"
+#include "utilities_xad.hpp"
+#include <ql/cashflows/coupon.hpp>
+#include <ql/indexes/ibor/euribor.hpp>
+#include <ql/instruments/swaption.hpp>
+#include <ql/instruments/vanillaswap.hpp>
+#include <ql/models/shortrate/onefactormodels/hullwhite.hpp>
+#include <ql/pricingengines/swap/discountingswapengine.hpp>
+#include <ql/pricingengines/swaption/treeswaptionengine.hpp>
+#include <ql/time/dategenerationrule.hpp>
+#include <ql/time/daycounters/thirty360.hpp>
+#include <ql/time/schedule.hpp>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+namespace {
+
+    struct BermudanSwaptionData {
+        Swap::Type type;
+        Real nominal = 1000.0;
+        Real fixedRate;
+        Real forwardRate;
+        Real a = 0.048696;
+        Real sigma = 0.0058904;
+    };
+
+}
+namespace {
+
+    template <class PriceFunc>
+    Real priceWithBumping(const BermudanSwaptionData& value,
+                          BermudanSwaptionData& derivatives,
+                          PriceFunc func) {
+        // Bumping
+        auto eps = 1e-7;
+        auto data = value;
+        auto v = func(data);
+
+        data.nominal += eps;
+        auto vplus = func(data);
+        derivatives.nominal = (vplus - v) / eps;
+        data = value;
+
+        data.fixedRate += eps;
+        vplus = func(data);
+        derivatives.fixedRate = (vplus - v) / eps;
+        data = value;
+
+        data.forwardRate += eps;
+        vplus = func(data);
+        derivatives.forwardRate = (vplus - v) / eps;
+        data = value;
+
+        data.a += eps;
+        vplus = func(data);
+        derivatives.a = (vplus - v) / eps;
+        data = value;
+
+        data.sigma += eps * .1;
+        vplus = func(data);
+        derivatives.sigma = (vplus - v) / eps / .1;
+
+        return v;
+    }
+
+    template <class PriceFunc>
+    Real priceWithAAD(const BermudanSwaptionData& values,
+                      BermudanSwaptionData& derivatives,
+                      PriceFunc func) {
+        // AAD
+        using tape_type = Real::tape_type;
+        tape_type tape;
+        auto data = values;
+        tape.registerInput(data.nominal);
+        tape.registerInput(data.fixedRate);
+        tape.registerInput(data.forwardRate);
+        tape.registerInput(data.a);
+        tape.registerInput(data.sigma);
+        tape.newRecording();
+
+        auto price = func(data);
+
+        tape.registerOutput(price);
+        derivative(price) = 1.0;
+        tape.computeAdjoints();
+
+        derivatives.nominal = derivative(data.nominal);
+        derivatives.fixedRate = derivative(data.fixedRate);
+        derivatives.forwardRate = derivative(data.forwardRate);
+        derivatives.a = derivative(data.a);
+        derivatives.sigma = derivative(data.sigma);
+
+        return price;
+    }
+}
+
+namespace {
+    Real priceBermudanSwaption(const BermudanSwaptionData& value) {
+        Integer startYears = 1;
+        Integer length = 5;
+        Natural settlementDays = 2;
+        RelinkableHandle<YieldTermStructure> termStructure;
+        termStructure.linkTo(
+            flatRate(Date(15, February, 2002), value.forwardRate, Actual365Fixed()));
+        auto index = ext::make_shared<Euribor6M>(termStructure);
+        Calendar calendar = index->fixingCalendar();
+        Date today = calendar.adjust(Date::todaysDate());
+        Date settlement = calendar.advance(today, settlementDays, Days);
+
+        Date start = calendar.advance(settlement, startYears, Years);
+        Date maturity = calendar.advance(start, length, Years);
+        Schedule fixedSchedule(start, maturity, Period(Annual), calendar, Unadjusted, Unadjusted,
+                               DateGeneration::Forward, false);
+        Schedule floatSchedule(start, maturity, Period(Semiannual), calendar, ModifiedFollowing,
+                               ModifiedFollowing, DateGeneration::Forward, false);
+        ext::shared_ptr<VanillaSwap> swap(new VanillaSwap(
+            value.type, value.nominal, fixedSchedule, value.fixedRate,
+            Thirty360(Thirty360::BondBasis), floatSchedule, index, 0.0, index->dayCounter()));
+        swap->setPricingEngine(
+            ext::shared_ptr<PricingEngine>(new DiscountingSwapEngine(termStructure)));
+        auto model = ext::make_shared<HullWhite>(termStructure, value.a, value.sigma);
+
+        std::vector<Date> exerciseDates;
+        const Leg& leg = swap->fixedLeg();
+        for (const auto& i : leg) {
+            auto coupon = ext::dynamic_pointer_cast<Coupon>(i);
+            exerciseDates.push_back(coupon->accrualStartDate());
+        }
+        auto exercise = ext::make_shared<BermudanExercise>(exerciseDates);
+
+        auto treeEngine = ext::make_shared<TreeSwaptionEngine>(model, 50);
+
+        Swaption swaption(swap, exercise);
+        swaption.setPricingEngine(treeEngine);
+
+        return swaption.NPV();
+    }
+}
+
+void BermudanSwaptionXadTest::testBermudanSwaptionDerivatives() {
+
+    SavedSettings save;
+    BOOST_TEST_MESSAGE("Testing bermudan swaption derivatives...");
+
+    // input
+    auto data = BermudanSwaptionData{Swap::Payer, 1000.00, 0.10, 0.04875825, 0.048696, 0.0058904};
+
+    // bumping
+    auto derivatives_bumping = BermudanSwaptionData{};
+    auto expected = priceWithBumping(data, derivatives_bumping, priceBermudanSwaption);
+
+    // aad
+    auto derivatives_aad = BermudanSwaptionData{};
+    auto actual = priceWithAAD(data, derivatives_aad, priceBermudanSwaption);
+
+    // compare
+    QL_CHECK_CLOSE(expected, actual, 1e-9);
+    QL_CHECK_CLOSE(derivatives_bumping.nominal, derivatives_aad.nominal, 1e-3);
+    QL_CHECK_CLOSE(derivatives_bumping.fixedRate, derivatives_aad.fixedRate, 1e-3);
+    QL_CHECK_CLOSE(derivatives_bumping.forwardRate, derivatives_aad.forwardRate, 1e-3);
+    QL_CHECK_CLOSE(derivatives_bumping.a, derivatives_aad.a, 1e-3);
+    QL_CHECK_CLOSE(derivatives_bumping.sigma, derivatives_aad.sigma, 1e-3);
+}
+
+test_suite* BermudanSwaptionXadTest::suite() {
+    auto* suite = BOOST_TEST_SUITE("bermudan swaption derivatives tests");
+
+    suite->add(QLXAD_TEST_CASE(&BermudanSwaptionXadTest::testBermudanSwaptionDerivatives));
+
+    return suite;
+}

--- a/test-suite/bermudanswaption_xad.cpp
+++ b/test-suite/bermudanswaption_xad.cpp
@@ -183,7 +183,10 @@ void BermudanSwaptionXadTest::testBermudanSwaptionDerivatives() {
 
     // compare
     QL_CHECK_CLOSE(expected, actual, 1e-9);
-    QL_CHECK_CLOSE(derivatives_bumping.nominal, derivatives_aad.nominal, 1e-3);
+    if (derivatives_bumping.nominal > 0.1)
+        QL_CHECK_CLOSE(derivatives_bumping.nominal, derivatives_aad.nominal, 1e-2);
+    else
+        QL_CHECK_SMALL(abs(derivatives_aad.nominal - derivatives_bumping.nominal), 1e-3);
     QL_CHECK_CLOSE(derivatives_bumping.fixedRate, derivatives_aad.fixedRate, 1e-3);
     QL_CHECK_CLOSE(derivatives_bumping.forwardRate, derivatives_aad.forwardRate, 1e-3);
     QL_CHECK_CLOSE(derivatives_bumping.a, derivatives_aad.a, 1e-3);

--- a/test-suite/bermudanswaption_xad.hpp
+++ b/test-suite/bermudanswaption_xad.hpp
@@ -1,8 +1,10 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*
- Copyright (C) 2005 Klaus Spanderen
- Copyright (C) 2022 Xcelerit
+ Copyright (C) 2003, 2004 Ferdinando Ametrano
+ Copyright (C) 2005, 2007 StatPro Italia srl
+ Copyright (C) 2005 Joseph Wang
+ Copyright (C) 2023 Xcelerit
 
  This file is part of QuantLib / XAD integration module.
  It is modified from QuantLib, a free-software/open-source library
@@ -23,8 +25,8 @@
 
 #include <boost/test/unit_test.hpp>
 
-class BatesModelXadTest {
+class BermudanSwaptionXadTest {
   public:
-    static void testBatesModelDerivatives();
+    static void testBermudanSwaptionDerivatives();
     static boost::unit_test_framework::test_suite* suite();
 };

--- a/test-suite/bonds_xad.cpp
+++ b/test-suite/bonds_xad.cpp
@@ -1,0 +1,187 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2003, 2004 Ferdinando Ametrano
+ Copyright (C) 2005, 2007 StatPro Italia srl
+ Copyright (C) 2005 Joseph Wang
+ Copyright (C) 2023 Xcelerit
+
+ This file is part of QuantLib / XAD integration module.
+ It is modified from QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "bonds_xad.hpp"
+#include "utilities_xad.hpp"
+#include <ql/experimental/callablebonds/callablebond.hpp>
+#include <ql/experimental/callablebonds/treecallablebondengine.hpp>
+#include <ql/instruments/bonds/fixedratebond.hpp>
+#include <ql/models/shortrate/onefactormodels/hullwhite.hpp>
+#include <ql/pricingengines/bond/discountingbondengine.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/termstructures/yield/zerocurve.hpp>
+#include <ql/time/calendars/unitedstates.hpp>
+#include <ql/time/dategenerationrule.hpp>
+#include <ql/time/daycounters/thirty360.hpp>
+#include <ql/time/schedule.hpp>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+namespace {
+
+    struct BondsData {
+        Real spotRate1;
+        Real spotRate2;
+        Real spotRate3;
+        Real couponRate;
+        Real faceValue;
+    };
+
+}
+namespace {
+
+    template <class PriceFunc>
+    Real priceWithBumping(const BondsData& value, BondsData& derivatives, PriceFunc func) {
+        // Bumping
+        auto eps = 1e-7;
+        auto data = value;
+        auto v = func(data);
+
+        data.spotRate1 += eps;
+        auto vplus = func(data);
+        derivatives.spotRate1 = (vplus - v) / eps;
+        data = value;
+
+        data.spotRate2 += eps;
+        vplus = func(data);
+        derivatives.spotRate2 = (vplus - v) / eps;
+        data = value;
+
+        data.spotRate3 += eps;
+        vplus = func(data);
+        derivatives.spotRate3 = (vplus - v) / eps;
+        data = value;
+
+        data.couponRate += eps;
+        vplus = func(data);
+        derivatives.couponRate = (vplus - v) / eps;
+        data = value;
+
+        data.faceValue += eps;
+        vplus = func(data);
+        derivatives.faceValue = (vplus - v) / eps;
+
+        return v;
+    }
+
+    template <class PriceFunc>
+    Real priceWithAAD(const BondsData& values, BondsData& derivatives, PriceFunc func) {
+        // AAD
+        using tape_type = Real::tape_type;
+        tape_type tape;
+        auto data = values;
+        tape.registerInput(data.spotRate1);
+        tape.registerInput(data.spotRate2);
+        tape.registerInput(data.spotRate3);
+        tape.registerInput(data.couponRate);
+        tape.registerInput(data.faceValue);
+        tape.newRecording();
+
+        auto price = func(data);
+
+        tape.registerOutput(price);
+        derivative(price) = 1.0;
+        tape.computeAdjoints();
+
+        derivatives.spotRate1 = derivative(data.spotRate1);
+        derivatives.spotRate2 = derivative(data.spotRate2);
+        derivatives.spotRate3 = derivative(data.spotRate3);
+        derivatives.couponRate = derivative(data.couponRate);
+        derivatives.faceValue = derivative(data.faceValue);
+
+        return price;
+    }
+}
+
+namespace {
+    Real priceBonds(const BondsData& value) {
+        Date today = Date(15, January, 2015);
+        Settings::instance().evaluationDate() = today;
+
+        std::vector<Date> spotDates = {Date(15, January, 2015), Date(15, July, 2015),
+                                       Date(15, January, 2016)};
+        std::vector<Real> spotRates = {value.spotRate1, value.spotRate2, value.spotRate3};
+        DayCounter dayCount = Thirty360(Thirty360::USA);
+        Calendar calendar = UnitedStates(UnitedStates::GovernmentBond);
+        Compounding compounding = Compounded;
+        Frequency compoundingFrequency = Annual;
+
+        Handle<YieldTermStructure> spotCurveHandle(ext::make_shared<ZeroCurve>(
+            spotDates, spotRates, dayCount, calendar, Linear(), compounding, compoundingFrequency));
+
+        Date issueDate = Date(15, January, 2015);
+        Date maturityDate = Date(15, January, 2016);
+
+        Schedule schedule(issueDate, maturityDate, Period(Semiannual), calendar, Unadjusted,
+                          Unadjusted, DateGeneration::Backward, false);
+        // build the coupon
+        std::vector<Real> coupons = {value.couponRate};
+
+        // construct the FixedRateBond
+        auto fixedRateBond =
+            ext::make_shared<FixedRateBond>(0, value.faceValue, schedule, coupons, dayCount);
+
+        auto bondEngine = ext::make_shared<DiscountingBondEngine>(spotCurveHandle);
+        fixedRateBond->setPricingEngine(bondEngine);
+
+        return fixedRateBond->NPV();
+    }
+}
+
+void BondsXadTest::testBondsDerivatives() {
+
+    SavedSettings save;
+    BOOST_TEST_MESSAGE("Testing bonds derivatives...");
+
+    // input
+    auto data = BondsData{0.0, 0.005, 0.007, 0.06, 100.0};
+
+    // bumping
+    auto derivatives_bumping = BondsData{};
+    auto expected = priceWithBumping(data, derivatives_bumping, priceBonds);
+
+    // aad
+    auto derivatives_aad = BondsData{};
+    auto actual = priceWithAAD(data, derivatives_aad, priceBonds);
+
+    // compare
+    QL_CHECK_CLOSE(expected, actual, 1e-9);
+    QL_CHECK_CLOSE(derivatives_bumping.spotRate1, derivatives_aad.spotRate1, 1e-3);
+    QL_CHECK_CLOSE(derivatives_bumping.spotRate2, derivatives_aad.spotRate2, 1e-3);
+    QL_CHECK_CLOSE(derivatives_bumping.spotRate3, derivatives_aad.spotRate3, 1e-3);
+    QL_CHECK_CLOSE(derivatives_bumping.couponRate, derivatives_aad.couponRate, 1e-3);
+    QL_CHECK_CLOSE(derivatives_bumping.faceValue, derivatives_aad.faceValue, 1e-3);
+}
+
+test_suite* BondsXadTest::suite() {
+    auto* suite = BOOST_TEST_SUITE("bonds derivatives tests");
+
+    suite->add(QLXAD_TEST_CASE(&BondsXadTest::testBondsDerivatives));
+
+    return suite;
+}

--- a/test-suite/bonds_xad.hpp
+++ b/test-suite/bonds_xad.hpp
@@ -1,8 +1,10 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*
- Copyright (C) 2005 Klaus Spanderen
- Copyright (C) 2022 Xcelerit
+ Copyright (C) 2003, 2004 Ferdinando Ametrano
+ Copyright (C) 2005, 2007 StatPro Italia srl
+ Copyright (C) 2005 Joseph Wang
+ Copyright (C) 2023 Xcelerit
 
  This file is part of QuantLib / XAD integration module.
  It is modified from QuantLib, a free-software/open-source library
@@ -23,8 +25,8 @@
 
 #include <boost/test/unit_test.hpp>
 
-class BatesModelXadTest {
+class BondsXadTest {
   public:
-    static void testBatesModelDerivatives();
+    static void testBondsDerivatives();
     static boost::unit_test_framework::test_suite* suite();
 };

--- a/test-suite/creditdefaultswap_xad.cpp
+++ b/test-suite/creditdefaultswap_xad.cpp
@@ -1,0 +1,193 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2003, 2004 Ferdinando Ametrano
+ Copyright (C) 2005, 2007 StatPro Italia srl
+ Copyright (C) 2005 Joseph Wang
+ Copyright (C) 2023 Xcelerit
+
+ This file is part of QuantLib / XAD integration module.
+ It is modified from QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "creditdefaultswap_xad.hpp"
+#include "utilities_xad.hpp"
+#include <ql/instruments/creditdefaultswap.hpp>
+#include <ql/pricingengines/credit/midpointcdsengine.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/termstructures/credit/flathazardrate.hpp>
+#include <ql/termstructures/defaulttermstructure.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/dategenerationrule.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <ql/time/schedule.hpp>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+namespace {
+
+    struct CreditDefaultSwapData {
+        // Build the CDS
+        Rate fixedRate;
+        Real notional;
+        Real recoveryRate;
+        Real hazardRate;
+        Real riskFreeRate;
+    };
+
+}
+
+namespace {
+
+    template <class PriceFunc>
+    Real priceWithBumping(const CreditDefaultSwapData& value,
+                          CreditDefaultSwapData& derivatives,
+                          PriceFunc func) {
+        // Bumping
+        auto eps = 1e-7;
+        auto data = value;
+        auto v = func(data);
+
+        data.fixedRate += eps;
+        auto vplus = func(data);
+        derivatives.fixedRate = (vplus - v) / eps;
+        data = value;
+
+        data.notional += 1;
+        vplus = func(data);
+        derivatives.notional = (vplus - v) / 1;
+        data = value;
+
+        data.recoveryRate += eps;
+        vplus = func(data);
+        derivatives.recoveryRate = (vplus - v) / eps;
+        data = value;
+
+        data.hazardRate += eps;
+        vplus = func(data);
+        derivatives.hazardRate = (vplus - v) / eps;
+        data = value;
+
+        data.riskFreeRate += eps;
+        vplus = func(data);
+        derivatives.riskFreeRate = (vplus - v) / eps;
+        data = value;
+
+        return v;
+    }
+
+    template <class PriceFunc>
+    Real priceWithAAD(const CreditDefaultSwapData& values,
+                      CreditDefaultSwapData& derivatives,
+                      PriceFunc func) {
+        // AAD
+        using tape_type = Real::tape_type;
+        tape_type tape;
+        auto data = values;
+        tape.registerInput(data.notional);
+        tape.registerInput(data.hazardRate);
+        tape.registerInput(data.recoveryRate);
+        tape.registerInput(data.fixedRate);
+        tape.registerInput(data.riskFreeRate);
+        tape.newRecording();
+
+        auto price = func(data);
+
+        tape.registerOutput(price);
+        derivative(price) = 1.0;
+        tape.computeAdjoints();
+
+        derivatives.notional = derivative(data.notional);
+        derivatives.hazardRate = derivative(data.hazardRate);
+        derivatives.recoveryRate = derivative(data.recoveryRate);
+        derivatives.fixedRate = derivative(data.fixedRate);
+        derivatives.riskFreeRate = derivative(data.riskFreeRate);
+
+        return price;
+    }
+}
+
+namespace {
+    Real priceCreditDefaultSwap(const CreditDefaultSwapData& value) {
+        DayCounter dayCount = Actual360();
+        // Initialize curves
+        Settings::instance().evaluationDate() = Date(9, June, 2006);
+        Date today = Settings::instance().evaluationDate();
+        Calendar calendar = TARGET();
+
+        Handle<Quote> hazardRate(ext::make_shared<SimpleQuote>(value.hazardRate));
+        RelinkableHandle<DefaultProbabilityTermStructure> probabilityCurve;
+        probabilityCurve.linkTo(
+            ext::make_shared<FlatHazardRate>(0, calendar, hazardRate, Actual360()));
+
+        RelinkableHandle<YieldTermStructure> discountCurve;
+
+        discountCurve.linkTo(ext::make_shared<FlatForward>(today, value.riskFreeRate, Actual360()));
+
+        // Build the schedule
+        Date issueDate = calendar.advance(today, -1, Years);
+        Date maturity = calendar.advance(issueDate, 10, Years);
+        Frequency frequency = Semiannual;
+        BusinessDayConvention convention = ModifiedFollowing;
+
+        Schedule schedule(issueDate, maturity, Period(frequency), calendar, convention, convention,
+                          DateGeneration::Forward, false);
+
+        auto cds =
+            ext::make_shared<CreditDefaultSwap>(Protection::Seller, value.notional, value.fixedRate,
+                                                schedule, convention, dayCount, true, true);
+        cds->setPricingEngine(ext::make_shared<MidPointCdsEngine>(
+            probabilityCurve, value.recoveryRate, discountCurve));
+        return cds->NPV();
+    }
+}
+
+void CreditDefaultSwapXadTest::testCreditDefaultSwapDerivatives() {
+
+    SavedSettings save;
+    BOOST_TEST_MESSAGE("Testing credit default swap derivatives...");
+
+    // input
+    auto data = CreditDefaultSwapData{0.0120, 10000.0, 0.4, 0.01234, 0.06};
+
+    // bumping
+    auto derivatives_bumping = CreditDefaultSwapData{};
+    auto expected = priceWithBumping(data, derivatives_bumping, priceCreditDefaultSwap);
+
+    // aad
+    auto derivatives_aad = CreditDefaultSwapData{};
+    auto actual = priceWithAAD(data, derivatives_aad, priceCreditDefaultSwap);
+
+    // compare
+    QL_CHECK_CLOSE(expected, actual, 1e-9);
+    QL_CHECK_CLOSE(derivatives_bumping.notional, derivatives_aad.notional, 1e-3);
+    QL_CHECK_CLOSE(derivatives_bumping.hazardRate, derivatives_aad.hazardRate, 1e-3);
+    QL_CHECK_CLOSE(derivatives_bumping.fixedRate, derivatives_aad.fixedRate, 1e-3);
+    QL_CHECK_CLOSE(derivatives_bumping.recoveryRate, derivatives_aad.recoveryRate, 1e-3);
+    QL_CHECK_CLOSE(derivatives_bumping.riskFreeRate, derivatives_aad.riskFreeRate, 1e-3);
+}
+
+test_suite* CreditDefaultSwapXadTest::suite() {
+    auto* suite = BOOST_TEST_SUITE("credit default swap derivatives tests");
+
+    suite->add(QLXAD_TEST_CASE(&CreditDefaultSwapXadTest::testCreditDefaultSwapDerivatives));
+
+    return suite;
+}

--- a/test-suite/creditdefaultswap_xad.hpp
+++ b/test-suite/creditdefaultswap_xad.hpp
@@ -2,7 +2,7 @@
 
 /*
  Copyright (C) 2005 Klaus Spanderen
- Copyright (C) 2022 Xcelerit
+ Copyright (C) 2023 Xcelerit
 
  This file is part of QuantLib / XAD integration module.
  It is modified from QuantLib, a free-software/open-source library
@@ -23,8 +23,8 @@
 
 #include <boost/test/unit_test.hpp>
 
-class BatesModelXadTest {
+class CreditDefaultSwapXadTest {
   public:
-    static void testBatesModelDerivatives();
+    static void testCreditDefaultSwapDerivatives();
     static boost::unit_test_framework::test_suite* suite();
 };

--- a/test-suite/europeanoption_xad.cpp
+++ b/test-suite/europeanoption_xad.cpp
@@ -1,0 +1,169 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2003, 2004 Ferdinando Ametrano
+ Copyright (C) 2005, 2007 StatPro Italia srl
+ Copyright (C) 2005 Joseph Wang
+ Copyright (C) 2023 Xcelerit
+
+ This file is part of QuantLib / XAD integration module.
+ It is modified from QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "europeanoption_xad.hpp"
+#include "utilities_xad.hpp"
+#include <ql/pricingengines/vanilla/analyticeuropeanengine.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/termstructures/volatility/equityfx/blackconstantvol.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+namespace {
+
+    struct EuropeanOptionData {
+        Option::Type type;
+        Real strike;
+        Real u;       // underlying
+        Rate r;       // risk-free rate
+        Real d;       // dividend Yield
+        Volatility v; // volatility
+    };
+
+}
+namespace {
+
+    template <class PriceFunc>
+    Real priceWithAnalytics(const EuropeanOptionData& value,
+                            EuropeanOptionData& derivatives,
+                            PriceFunc func) {
+        auto data = value;
+        auto v = func(data);
+
+        derivatives.u = v[4];
+        derivatives.strike = v[2];
+        derivatives.r = v[1];
+        derivatives.v = v[3];
+        derivatives.d = v[5];
+
+        return v[0];
+    }
+
+    template <class PriceFunc>
+    Real priceWithAAD(const EuropeanOptionData& values,
+                      EuropeanOptionData& derivatives,
+                      PriceFunc func) {
+        // AAD
+        using tape_type = Real::tape_type;
+        tape_type tape;
+        auto data = values;
+        tape.registerInput(data.d);
+        tape.registerInput(data.r);
+        tape.registerInput(data.strike);
+        tape.registerInput(data.u);
+        tape.registerInput(data.v);
+        tape.newRecording();
+
+        auto price = func(data)[0];
+
+        tape.registerOutput(price);
+        derivative(price) = 1.0;
+        tape.computeAdjoints();
+
+        derivatives.d = derivative(data.d);
+        derivatives.r = derivative(data.r);
+        derivatives.strike = derivative(data.strike);
+        derivatives.u = derivative(data.u);
+        derivatives.v = derivative(data.v);
+
+        return price;
+    }
+}
+
+namespace {
+    std::array<Real, 6> priceEuropeanOption(const EuropeanOptionData& value) {
+        // set up dates
+        Calendar calendar = TARGET();
+        Date todaysDate(15, May, 1998);
+        Date settlementDate(17, May, 1998);
+        Settings::instance().evaluationDate() = todaysDate;
+
+        // our options
+        Option::Type type(Option::Put);
+        DayCounter dayCounter = Actual365Fixed();
+        Date maturity(17, May, 1999);
+        auto exercise = ext::make_shared<EuropeanExercise>(maturity);
+
+        Handle<Quote> underlyingH(ext::make_shared<SimpleQuote>(value.u));
+
+        // bootstrap the yield/dividend/vol curves
+        Handle<YieldTermStructure> flatTermStructure(
+            ext::make_shared<FlatForward>(settlementDate, value.r, dayCounter));
+        Handle<YieldTermStructure> flatDividendTS(
+            ext::make_shared<FlatForward>(settlementDate, value.d, dayCounter));
+        Handle<BlackVolTermStructure> flatVolTS(
+            ext::make_shared<BlackConstantVol>(settlementDate, calendar, value.v, dayCounter));
+        auto payoff = ext::make_shared<PlainVanillaPayoff>(type, value.strike);
+        auto bsmProcess = ext::make_shared<BlackScholesMertonProcess>(underlyingH, flatDividendTS,
+                                                                      flatTermStructure, flatVolTS);
+
+        // option
+        auto european = ext::make_shared<VanillaOption>(payoff, exercise);
+        // computing the option price with the analytic Black-Scholes formulae
+        european->setPricingEngine(ext::make_shared<AnalyticEuropeanEngine>(bsmProcess));
+        std::array<Real, 6> f_array = {
+            european->NPV(),  european->rho(),   european->strikeSensitivity(),
+            european->vega(), european->delta(), european->dividendRho()};
+        return f_array;
+    }
+}
+
+void EuropeanOptionXadTest::testEuropeanOptionDerivatives() {
+
+    SavedSettings save;
+    BOOST_TEST_MESSAGE("Testing European options derivatives...");
+
+    // input
+    auto data = EuropeanOptionData{Option::Call, 100.00, 90.00, 0.10, 0.10, 0.10};
+
+    // analytics
+    auto derivatives_analytics = EuropeanOptionData{};
+    auto expected = priceWithAnalytics(data, derivatives_analytics, priceEuropeanOption);
+
+    // aad
+    auto derivatives_aad = EuropeanOptionData{};
+    auto actual = priceWithAAD(data, derivatives_aad, priceEuropeanOption);
+
+    // compare
+    QL_CHECK_CLOSE(expected, actual, 1e-9);
+    QL_CHECK_CLOSE(derivatives_analytics.d, derivatives_aad.d, 1e-7);
+    QL_CHECK_CLOSE(derivatives_analytics.r, derivatives_aad.r, 1e-7);
+    QL_CHECK_CLOSE(derivatives_analytics.u, derivatives_aad.u, 1e-7);
+    QL_CHECK_CLOSE(derivatives_analytics.strike, derivatives_aad.strike, 1e-7);
+    QL_CHECK_CLOSE(derivatives_analytics.v, derivatives_aad.v, 1e-7);
+}
+
+test_suite* EuropeanOptionXadTest::suite() {
+    auto* suite = BOOST_TEST_SUITE("european option derivatives tests");
+
+    suite->add(QLXAD_TEST_CASE(&EuropeanOptionXadTest::testEuropeanOptionDerivatives));
+
+    return suite;
+}

--- a/test-suite/europeanoption_xad.hpp
+++ b/test-suite/europeanoption_xad.hpp
@@ -1,8 +1,10 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*
- Copyright (C) 2005 Klaus Spanderen
- Copyright (C) 2022 Xcelerit
+ Copyright (C) 2003, 2004 Ferdinando Ametrano
+ Copyright (C) 2005, 2007 StatPro Italia srl
+ Copyright (C) 2005 Joseph Wang
+ Copyright (C) 2023 Xcelerit
 
  This file is part of QuantLib / XAD integration module.
  It is modified from QuantLib, a free-software/open-source library
@@ -23,8 +25,8 @@
 
 #include <boost/test/unit_test.hpp>
 
-class BatesModelXadTest {
+class EuropeanOptionXadTest {
   public:
-    static void testBatesModelDerivatives();
+    static void testEuropeanOptionDerivatives();
     static boost::unit_test_framework::test_suite* suite();
 };

--- a/test-suite/forwardrateagreement_xad.cpp
+++ b/test-suite/forwardrateagreement_xad.cpp
@@ -1,0 +1,190 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2003, 2004 Ferdinando Ametrano
+ Copyright (C) 2005, 2007 StatPro Italia srl
+ Copyright (C) 2005 Joseph Wang
+ Copyright (C) 2023 Xcelerit
+
+ This file is part of QuantLib / XAD integration module.
+ It is modified from QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "forwardrateagreement_xad.hpp"
+#include "utilities_xad.hpp"
+#include <ql/indexes/ibor/usdlibor.hpp>
+#include <ql/instruments/forwardrateagreement.hpp>
+#include <ql/termstructures/yield/zerocurve.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/calendars/unitedstates.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <ql/time/period.hpp>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+namespace {
+
+    struct ForwardRateAgreementData {
+        Real nominal;
+        Real spotRate1;
+        Real spotRate2;
+        Real spotRate3;
+        Real rate;
+    };
+
+}
+
+namespace {
+
+    template <class PriceFunc>
+    Real priceWithBumping(const ForwardRateAgreementData& value,
+                          ForwardRateAgreementData& derivatives,
+                          PriceFunc func) {
+        // Bumping
+        auto eps = 1e-7;
+        auto data = value;
+        auto v = func(data);
+
+        data.nominal += 1;
+        auto vplus = func(data);
+        derivatives.nominal = (vplus - v) / 1;
+        data = value;
+
+        data.spotRate1 += eps;
+        vplus = func(data);
+        derivatives.spotRate1 = (vplus - v) / eps;
+        data = value;
+
+        data.spotRate2 += eps;
+        vplus = func(data);
+        derivatives.spotRate2 = (vplus - v) / eps;
+        data = value;
+
+        data.spotRate3 += eps;
+        vplus = func(data);
+        derivatives.spotRate3 = (vplus - v) / eps;
+        data = value;
+
+        data.rate += eps;
+        vplus = func(data);
+        derivatives.rate = (vplus - v) / eps;
+
+        return v;
+    }
+
+    template <class PriceFunc>
+    Real priceWithAAD(const ForwardRateAgreementData& values,
+                      ForwardRateAgreementData& derivatives,
+                      PriceFunc func) {
+        // AAD
+        using tape_type = Real::tape_type;
+        tape_type tape;
+        auto data = values;
+        tape.registerInput(data.nominal);
+        tape.registerInput(data.spotRate1);
+        tape.registerInput(data.spotRate2);
+        tape.registerInput(data.spotRate3);
+        tape.registerInput(data.rate);
+        tape.newRecording();
+
+        auto price = func(data);
+
+        tape.registerOutput(price);
+        derivative(price) = 1.0;
+        tape.computeAdjoints();
+
+        derivatives.nominal = derivative(data.nominal);
+        derivatives.spotRate1 = derivative(data.spotRate1);
+        derivatives.spotRate2 = derivative(data.spotRate2);
+        derivatives.spotRate3 = derivative(data.spotRate3);
+        derivatives.rate = derivative(data.rate);
+
+        return price;
+    }
+}
+
+namespace {
+    Real priceForwardRateAgreement(const ForwardRateAgreementData& value) {
+        Date today(30, June, 2020);
+        Settings::instance().evaluationDate() = today;
+
+        std::vector<Date> spotDates;
+        spotDates.push_back(Date(30, June, 2020));
+        spotDates.push_back(Date(31, December, 2020));
+        spotDates.push_back(Date(30, June, 2021));
+        std::vector<Real> spotRates;
+        spotRates.push_back(value.spotRate1);
+        spotRates.push_back(value.spotRate2);
+        spotRates.push_back(value.spotRate3);
+
+        DayCounter dayConvention = Actual360();
+        Calendar calendar = UnitedStates(UnitedStates::GovernmentBond);
+        Date startDate = calendar.advance(today, Period(3, Months));
+        Date maturityDate = calendar.advance(startDate, Period(3, Months));
+
+        Compounding compounding = Simple;
+        Frequency compoundingFrequency = Annual;
+
+        Handle<YieldTermStructure> spotCurve(
+            ext::make_shared<ZeroCurve>(spotDates, spotRates, dayConvention, calendar, Linear(),
+                                        compounding, compoundingFrequency));
+        spotCurve->enableExtrapolation();
+
+        auto index = ext::make_shared<USDLibor>(Period(3, Months), spotCurve);
+        index->addFixing(Date(26, June, 2020), 0.05);
+
+        ForwardRateAgreement fra(index, startDate, maturityDate, Position::Long, value.rate,
+                                 value.nominal, spotCurve);
+
+        return fra.NPV();
+    }
+}
+
+void ForwardRateAgreementXadTest::testForwardRateAgreementDerivatives() {
+
+    SavedSettings save;
+    BOOST_TEST_MESSAGE("Testing forward rate agreement derivatives...");
+
+    // input
+    auto data = ForwardRateAgreementData{100000, 0.5, 0.5, 0.5, 0.06};
+
+    // bumping
+    auto derivatives_bumping = ForwardRateAgreementData{};
+    auto expected = priceWithBumping(data, derivatives_bumping, priceForwardRateAgreement);
+
+    // aad
+    auto derivatives_aad = ForwardRateAgreementData{};
+    auto actual = priceWithAAD(data, derivatives_aad, priceForwardRateAgreement);
+
+    // compare
+    QL_CHECK_CLOSE(expected, actual, 1e-9);
+    QL_CHECK_CLOSE(derivatives_bumping.nominal, derivatives_aad.nominal, 1e-3);
+    QL_CHECK_CLOSE(derivatives_bumping.spotRate1, derivatives_aad.spotRate1, 1e-3);
+    QL_CHECK_CLOSE(derivatives_bumping.spotRate2, derivatives_aad.spotRate2, 1e-3);
+    QL_CHECK_CLOSE(derivatives_bumping.spotRate3, derivatives_aad.spotRate3, 1e-3);
+    QL_CHECK_CLOSE(derivatives_bumping.rate, derivatives_aad.rate, 1e-3);
+}
+
+test_suite* ForwardRateAgreementXadTest::suite() {
+    auto* suite = BOOST_TEST_SUITE("forward rate agreement derivatives tests");
+
+    suite->add(QLXAD_TEST_CASE(&ForwardRateAgreementXadTest::testForwardRateAgreementDerivatives));
+
+    return suite;
+}

--- a/test-suite/forwardrateagreement_xad.hpp
+++ b/test-suite/forwardrateagreement_xad.hpp
@@ -1,8 +1,10 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*
- Copyright (C) 2005 Klaus Spanderen
- Copyright (C) 2022 Xcelerit
+ Copyright (C) 2003, 2004 Ferdinando Ametrano
+ Copyright (C) 2005, 2007 StatPro Italia srl
+ Copyright (C) 2005 Joseph Wang
+ Copyright (C) 2023 Xcelerit
 
  This file is part of QuantLib / XAD integration module.
  It is modified from QuantLib, a free-software/open-source library
@@ -23,8 +25,8 @@
 
 #include <boost/test/unit_test.hpp>
 
-class BatesModelXadTest {
+class ForwardRateAgreementXadTest {
   public:
-    static void testBatesModelDerivatives();
+    static void testForwardRateAgreementDerivatives();
     static boost::unit_test_framework::test_suite* suite();
 };

--- a/test-suite/hestonmodel_xad.cpp
+++ b/test-suite/hestonmodel_xad.cpp
@@ -1,0 +1,309 @@
+// /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+// /*
+//  Copyright (C) 2023 Xcelerit
+
+//  This file is part of QuantLib / XAD integration module.
+//  It is modified from QuantLib, a free-software/open-source library
+//  for financial quantitative analysts and developers - http://quantlib.org/
+
+//  QuantLib is free software: you can redistribute it and/or modify it
+//  under the terms of the QuantLib license.  You should have received a
+//  copy of the license along with this program; if not, please email
+//  <quantlib-dev@lists.sf.net>. The license is also available online at
+//  <http://quantlib.org/license.shtml>.
+
+//  This program is distributed in the hope that it will be useful, but WITHOUT
+//  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+//  FOR A PARTICULAR PURPOSE.  See the license for more details.
+// */
+
+#include "hestonmodel_xad.hpp"
+#include "utilities_xad.hpp"
+#include <ql/math/optimization/levenbergmarquardt.hpp>
+#include <ql/models/equity/hestonmodel.hpp>
+#include <ql/models/equity/hestonmodelhelper.hpp>
+#include <ql/models/equity/piecewisetimedependenthestonmodel.hpp>
+#include <ql/pricingengines/vanilla/analytichestonengine.hpp>
+#include <ql/pricingengines/vanilla/coshestonengine.hpp>
+#include <ql/pricingengines/vanilla/fdhestonvanillaengine.hpp>
+#include <ql/processes/hestonprocess.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/termstructures/yield/zerocurve.hpp>
+#include <ql/termstructures/yieldtermstructure.hpp>
+#include <ql/time/calendars/nullcalendar.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <ql/time/daycounters/actualactual.hpp>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+namespace {
+
+    struct ModelData {
+        std::vector<Date> dates;
+        std::vector<Real> rates;
+        DayCounter dayCounter;
+        Calendar calendar;
+        std::vector<Integer> t;
+        std::vector<Real> v;
+        std::vector<Real> strike;
+        Handle<Quote> s0;
+        Date settlementDate;
+    };
+
+}
+namespace {
+
+    template <class PriceFunc>
+    Real priceWithBumping(ext::shared_ptr<QuantLib::HestonModel>& model,
+                          const ModelData& value,
+                          std::vector<Real>& derivatives_rates,
+                          std::vector<Real>& derivatives_v,
+                          std::vector<Real>& derivatives_strike,
+                          PriceFunc func) {
+        // Bumping
+        auto eps = 1e-7;
+        auto data = value;
+        auto v = func(model, data);
+
+        for (std::size_t i = 0; i < data.strike.size(); ++i) {
+            data.strike[i] += 1;
+            auto vplus = func(model, data);
+            derivatives_strike.push_back((vplus - v) / 1);
+            data = value;
+        }
+        for (std::size_t i = 0; i < data.v.size(); ++i) {
+            data.v[i] += eps;
+            auto vplus = func(model, data);
+            derivatives_v.push_back((vplus - v) / eps);
+            data = value;
+        }
+        for (std::size_t i = 0; i < data.rates.size(); ++i) {
+            data.rates[i] += eps;
+            auto vplus = func(model, data);
+            derivatives_rates.push_back((vplus - v) / eps);
+            data = value;
+        }
+
+        return v;
+    }
+    template <class PriceFunc>
+    Real priceWithAAD(ext::shared_ptr<QuantLib::HestonModel>& model,
+                      const ModelData& value,
+                      std::vector<Real>& derivatives_v,
+                      std::vector<Real>& derivatives_strikes,
+                      std::vector<Real>& derivatives_rates,
+                      PriceFunc func) {
+        // AAD
+        using tape_type = Real::tape_type;
+        tape_type tape;
+
+        std::vector<Real> rates = value.rates;
+        std::vector<Real> volatilities = value.v;
+        std::vector<Real> strikes = value.strike;
+        tape.registerInputs(rates);
+        tape.registerInputs(strikes);
+        tape.registerInputs(volatilities);
+        tape.newRecording();
+
+        Real v = func(model, value);
+
+        // get the values
+        tape.registerOutput(v);
+        derivative(v) = 1.0;
+        tape.computeAdjoints();
+
+        std::transform(rates.begin(), rates.end(), std::back_inserter(derivatives_rates),
+                       [](const Real& q) { return derivative(q); });
+        std::transform(strikes.begin(), strikes.end(), std::back_inserter(derivatives_strikes),
+                       [](const Real& q) { return derivative(q); });
+        std::transform(volatilities.begin(), volatilities.end(), std::back_inserter(derivatives_v),
+                       [](const Real& q) { return derivative(q); });
+        return v;
+    }
+}
+namespace {
+
+    struct CalibrationMarketData {
+        Handle<Quote> s0;
+        Handle<YieldTermStructure> riskFreeTS, dividendYield;
+        std::vector<ext::shared_ptr<CalibrationHelper>> options;
+    };
+
+    CalibrationMarketData getDAXCalibrationMarketData(const ModelData& value) {
+        // FLOATING_POINT_EXCEPTION
+        Handle<YieldTermStructure> riskFreeTS(
+            ext::make_shared<ZeroCurve>(value.dates, value.rates, value.dayCounter));
+
+        Handle<YieldTermStructure> dividendYield(ext::make_shared<FlatForward>(
+            0, NullCalendar(), Handle<Quote>(ext::make_shared<SimpleQuote>(0.0)),
+            value.dayCounter));
+
+        std::vector<ext::shared_ptr<CalibrationHelper>> options;
+
+        for (Size s = 0; s < 13; ++s) {
+            for (Size m = 0; m < 8; ++m) {
+                Handle<Quote> vol(ext::make_shared<SimpleQuote>(value.v[s * 8 + m]));
+
+                Period maturity((int)((value.t[m] + 3) / 7.), Weeks); // round to weeks
+                options.push_back(ext::make_shared<HestonModelHelper>(
+                    maturity, value.calendar, value.s0, value.strike[s], vol, riskFreeTS,
+                    dividendYield, BlackCalibrationHelper::ImpliedVolError));
+            }
+        }
+
+        CalibrationMarketData marketData = {value.s0, riskFreeTS, dividendYield, options};
+
+        return marketData;
+    }
+
+}
+
+ext::shared_ptr<QuantLib::HestonModel> HestonModelCalibration(const ModelData& value) {
+    CalibrationMarketData marketData = getDAXCalibrationMarketData(value);
+
+    const Handle<YieldTermStructure> riskFreeTS = marketData.riskFreeTS;
+    const Handle<YieldTermStructure> dividendTS = marketData.dividendYield;
+    const Handle<Quote> S0 = marketData.s0;
+
+    const std::vector<ext::shared_ptr<CalibrationHelper>>& options = marketData.options;
+
+    const Real v0 = 0.5;
+    const Real kappa = 1.0;
+    const Real theta = 0.1;
+    const Real sigma = 0.5;
+    const Real rho = -0.0;
+
+    const ext::shared_ptr<HestonModel> model = ext::make_shared<HestonModel>(
+        ext::make_shared<HestonProcess>(riskFreeTS, dividendTS, S0, v0, kappa, theta, sigma, rho));
+
+    auto engine = ext::make_shared<COSHestonEngine>(model);
+
+    const Array params = model->params();
+    model->setParams(params);
+    for (const auto& option : options)
+        ext::dynamic_pointer_cast<BlackCalibrationHelper>(option)->setPricingEngine(engine);
+
+    LevenbergMarquardt om(1e-8, 1e-8, 1e-8);
+    model->calibrate(options, om, EndCriteria(400, 40, 1.0e-8, 1.0e-8, 1.0e-8));
+
+    return model;
+}
+
+Real priceHestonModel(ext::shared_ptr<QuantLib::HestonModel>& model, const ModelData& value) {
+    const Date maturityDate = value.settlementDate + Period(1, Years);
+
+    const ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(maturityDate);
+
+    const ext::shared_ptr<PricingEngine> cosEngine(
+        ext::make_shared<COSHestonEngine>(model, 25, 600));
+    CalibrationMarketData marketData = getDAXCalibrationMarketData(value);
+
+    const Handle<Quote> S0 = marketData.s0;
+
+    auto payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, S0->value() + 20);
+
+    VanillaOption option(payoff, exercise);
+
+    option.setPricingEngine(cosEngine);
+
+    return option.NPV();
+}
+
+
+void printResults(Real v, const std::vector<Real>& derivatives) {
+
+
+    for (std::size_t i = 0; i < derivatives.size(); ++i)
+        std::cout << "derivatives " << i << " = " << derivatives[i] << "\n";
+}
+
+void HestonModelXadTest::testHestonModelDerivatives() {
+    Date settlementDate(16, September, 2015);
+    Settings::instance().evaluationDate() = settlementDate;
+
+    DayCounter dayCounter = Actual365Fixed();
+    Calendar calendar = TARGET();
+
+    std::vector<Integer> t = {13, 41, 75, 165, 256, 345, 524, 703};
+    std::vector<Rate> r = {0.0357, 0.0349, 0.0341, 0.0355, 0.0359, 0.0368, 0.0386, 0.0401};
+
+
+    std::vector<Date> dates;
+    std::vector<Rate> rates;
+    dates.push_back(settlementDate);
+    rates.push_back(0.0357);
+    Size i;
+    for (i = 0; i < 8; ++i) {
+        dates.push_back(settlementDate + t[i]);
+        rates.push_back(r[i]);
+    }
+    std::vector<Volatility> v = {
+        0.6625, 0.4875, 0.4204, 0.3667, 0.3431, 0.3267, 0.3121, 0.3121, 0.6007, 0.4543, 0.3967,
+        0.3511, 0.3279, 0.3154, 0.2984, 0.2921, 0.5084, 0.4221, 0.3718, 0.3327, 0.3155, 0.3027,
+        0.2919, 0.2889, 0.4541, 0.3869, 0.3492, 0.3149, 0.2963, 0.2926, 0.2819, 0.2800, 0.4060,
+        0.3607, 0.3330, 0.2999, 0.2887, 0.2811, 0.2751, 0.2775, 0.3726, 0.3396, 0.3108, 0.2781,
+        0.2788, 0.2722, 0.2661, 0.2686, 0.3550, 0.3277, 0.3012, 0.2781, 0.2781, 0.2661, 0.2661,
+        0.2681, 0.3428, 0.3209, 0.2958, 0.2740, 0.2688, 0.2627, 0.2580, 0.2620, 0.3302, 0.3062,
+        0.2799, 0.2631, 0.2573, 0.2533, 0.2504, 0.2544, 0.3343, 0.2959, 0.2705, 0.2540, 0.2504,
+        0.2464, 0.2448, 0.2462, 0.3460, 0.2845, 0.2624, 0.2463, 0.2425, 0.2385, 0.2373, 0.2422,
+        0.3857, 0.2860, 0.2578, 0.2399, 0.2357, 0.2327, 0.2312, 0.2351, 0.3976, 0.2860, 0.2607,
+        0.2356, 0.2297, 0.2268, 0.2241, 0.2320};
+
+    Handle<Quote> s0(ext::make_shared<SimpleQuote>(4468.17));
+    std::vector<Real> strike = {3400, 3600, 3800, 4000, 4200, 4400, 4500,
+                                4600, 4800, 5000, 5200, 5400, 5600};
+
+    SavedSettings save;
+    BOOST_TEST_MESSAGE("Testing Heston model derivatives...");
+
+    // input
+    auto data = ModelData{dates, rates, dayCounter, calendar, t, v, strike, s0, settlementDate};
+    auto model = HestonModelCalibration(data);
+
+    std::cout.precision(15);
+
+    // bumping
+    std::vector<Real> derivatives_bumping_v;
+    std::vector<Real> derivatives_bumping_rates;
+    std::vector<Real> derivatives_bumping_strikes;
+
+
+    auto expected = priceWithBumping(model, data, derivatives_bumping_rates, derivatives_bumping_v,
+                                     derivatives_bumping_strikes, priceHestonModel);
+
+    // aad
+    std::vector<Real> derivatives_aad_v;
+    std::vector<Real> derivatives_aad_rates;
+    std::vector<Real> derivatives_aad_strikes;
+
+    auto actual = priceWithAAD(model, data, derivatives_aad_v, derivatives_aad_strikes,
+                               derivatives_aad_rates, priceHestonModel);
+
+    // compare
+    QL_CHECK_CLOSE(expected, actual, 1e-9);
+    for (std::size_t i = 0; i < derivatives_aad_v.size(); ++i) {
+        QL_CHECK_CLOSE(derivatives_bumping_v[i], derivatives_aad_v[i], 1e-3);
+    }
+    for (std::size_t i = 0; i < derivatives_aad_strikes.size(); ++i) {
+        QL_CHECK_CLOSE(derivatives_bumping_strikes[i], derivatives_aad_strikes[i], 1e-3);
+    }
+    for (std::size_t i = 0; i < derivatives_aad_rates.size(); ++i) {
+        QL_CHECK_CLOSE(derivatives_bumping_rates[i], derivatives_aad_rates[i], 1e-3);
+    }
+}
+
+test_suite* HestonModelXadTest::suite() {
+    auto* suite = BOOST_TEST_SUITE("Heston model derivatives tests");
+
+    suite->add(QLXAD_TEST_CASE(&HestonModelXadTest::testHestonModelDerivatives));
+
+    return suite;
+}

--- a/test-suite/hestonmodel_xad.hpp
+++ b/test-suite/hestonmodel_xad.hpp
@@ -1,8 +1,10 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*
- Copyright (C) 2005 Klaus Spanderen
- Copyright (C) 2022 Xcelerit
+ Copyright (C) 2003, 2004 Ferdinando Ametrano
+ Copyright (C) 2005, 2007 StatPro Italia srl
+ Copyright (C) 2005 Joseph Wang
+ Copyright (C) 2023 Xcelerit
 
  This file is part of QuantLib / XAD integration module.
  It is modified from QuantLib, a free-software/open-source library
@@ -23,8 +25,8 @@
 
 #include <boost/test/unit_test.hpp>
 
-class BatesModelXadTest {
+class HestonModelXadTest {
   public:
-    static void testBatesModelDerivatives();
+    static void testHestonModelDerivatives();
     static boost::unit_test_framework::test_suite* suite();
 };

--- a/test-suite/quantlibtestsuite_xad.cpp
+++ b/test-suite/quantlibtestsuite_xad.cpp
@@ -33,7 +33,15 @@
 #endif
 
 #include "americanoption_xad.hpp"
+#include "barrieroption_xad.hpp"
 #include "batesmodel_xad.hpp"
+#include "bermudanswaption_xad.hpp"
+#include "bonds_xad.hpp"
+#include "creditdefaultswap_xad.hpp"
+#include "europeanoption_xad.hpp"
+#include "forwardrateagreement_xad.hpp"
+#include "hestonmodel_xad.hpp"
+#include "swap_xad.hpp"
 #include "utilities_xad.hpp"
 
 using namespace boost::unit_test_framework;
@@ -68,7 +76,16 @@ test_suite* init_unit_test_suite(int, char*[]) {
     auto* test = BOOST_TEST_SUITE("QuantLib XAD test suite");
 
     test->add(AmericanOptionXadTest::suite());
+    test->add(EuropeanOptionXadTest::suite());
+    test->add(BarrierOptionXadTest::suite());
     test->add(BatesModelXadTest::suite());
+    test->add(SwapXadTest::suite());
+    test->add(CreditDefaultSwapXadTest::suite());
+    test->add(ForwardRateAgreementXadTest::suite());
+    test->add(BondsXadTest::suite());
+    test->add(BermudanSwaptionXadTest::suite());
+    test->add(HestonModelXadTest::suite());
+
 
     return test;
 }

--- a/test-suite/swap_xad.cpp
+++ b/test-suite/swap_xad.cpp
@@ -1,0 +1,193 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2003, 2004 Ferdinando Ametrano
+ Copyright (C) 2005, 2007 StatPro Italia srl
+ Copyright (C) 2005 Joseph Wang
+ Copyright (C) 2023 Xcelerit
+
+ This file is part of QuantLib / XAD integration module.
+ It is modified from QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "swap_xad.hpp"
+#include "utilities_xad.hpp"
+#include <ql/cashflows/couponpricer.hpp>
+#include <ql/cashflows/fixedratecoupon.hpp>
+#include <ql/cashflows/iborcoupon.hpp>
+#include <ql/currencies/europe.hpp>
+#include <ql/indexes/ibor/euribor.hpp>
+#include <ql/instruments/vanillaswap.hpp>
+#include <ql/pricingengines/swap/discountingswapengine.hpp>
+#include <ql/termstructures/volatility/optionlet/constantoptionletvol.hpp>
+#include <ql/time/daycounters/simpledaycounter.hpp>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+namespace {
+
+    struct SwapData {
+        VanillaSwap::Type type;
+        Real n;       // nominal
+        Real s;       // spread
+        Rate g;       // gearing
+        Volatility v; // volatility
+    };
+
+}
+
+namespace {
+
+    template <class PriceFunc>
+    Real priceWithBumping(const SwapData& value, SwapData& derivatives, PriceFunc func) {
+        // bumping
+        auto eps = 1e-7;
+        auto data = value;
+        auto v = func(data);
+
+        data.n += 1;
+        auto vplus = func(data);
+        derivatives.n = (vplus - v) / 1;
+        data = value;
+
+        data.s += eps;
+        vplus = func(data);
+        derivatives.s = (vplus - v) / eps;
+        data = value;
+
+        data.g += eps;
+        vplus = func(data);
+        derivatives.g = (vplus - v) / eps;
+        data = value;
+
+
+        data.v += eps;
+        vplus = func(data);
+        derivatives.v = (vplus - v) / eps;
+        data = value;
+
+        return v;
+    }
+
+    template <class PriceFunc>
+    Real priceWithAAD(const SwapData& values, SwapData& derivatives, PriceFunc func) {
+        // AAD
+        using tape_type = Real::tape_type;
+        tape_type tape;
+        auto data = values;
+
+        tape.registerInput(data.n);
+        tape.registerInput(data.s);
+        tape.registerInput(data.g);
+        tape.registerInput(data.v);
+
+
+        tape.newRecording();
+
+        auto price = func(data);
+
+        tape.registerOutput(price);
+        derivative(price) = 1.0;
+        tape.computeAdjoints();
+
+        derivatives.n = derivative(data.n);
+        derivatives.s = derivative(data.s);
+        derivatives.g = derivative(data.g);
+        derivatives.v = derivative(data.v);
+
+
+        return price;
+    }
+}
+
+namespace {
+    Real priceSwap(const SwapData& value) {
+        RelinkableHandle<YieldTermStructure> termStructure;
+        Calendar calendar = NullCalendar();
+        Date today = calendar.adjust(Settings::instance().evaluationDate());
+        Date settlement = calendar.advance(today, 2, Days);
+        termStructure.linkTo(flatRate(settlement, 0.05, Actual365Fixed()));
+        Date maturity = today + 5 * Years;
+        Natural fixingDays = 0;
+
+        Schedule schedule(today, maturity, Period(Annual), calendar, Following, Following,
+                          DateGeneration::Forward, false);
+        DayCounter dayCounter = SimpleDayCounter();
+        auto index = ext::make_shared<IborIndex>("dummy", 1 * Years, 0, EURCurrency(), calendar,
+                                                 Following, false, dayCounter, termStructure);
+        Rate oneYear = 0.05;
+        Rate r = std::log(1.0 + oneYear);
+        termStructure.linkTo(flatRate(today, r, dayCounter));
+
+
+        std::vector<Rate> coupons(1, oneYear);
+        Leg fixedLeg =
+            FixedRateLeg(schedule).withNotionals(value.n).withCouponRates(coupons, dayCounter);
+
+        Handle<OptionletVolatilityStructure> vol(ext::make_shared<ConstantOptionletVolatility>(
+            today, NullCalendar(), Following, value.v, dayCounter));
+        auto pricer = ext::make_shared<BlackIborCouponPricer>(vol);
+
+        Leg floatingLeg = IborLeg(schedule, index)
+                              .withNotionals(value.n)
+                              .withPaymentDayCounter(dayCounter)
+                              .withFixingDays(fixingDays)
+                              .withGearings(value.g)
+                              .withSpreads(value.s)
+                              .inArrears();
+        setCouponPricer(floatingLeg, pricer);
+
+        auto swap = ext::make_shared<Swap>(floatingLeg, fixedLeg);
+        swap->setPricingEngine(
+            ext::shared_ptr<PricingEngine>(new DiscountingSwapEngine(termStructure)));
+
+        return swap->NPV();
+    }
+}
+void SwapXadTest::testSwapDerivatives() {
+
+    SavedSettings save;
+    BOOST_TEST_MESSAGE("Testing European options derivatives...");
+
+    // input
+    auto data = SwapData{VanillaSwap::Payer, 1000000.0, -0.001, 0.01, 0.22};
+
+    // Bumping
+    auto derivatives_Bumping = SwapData{};
+    auto expected = priceWithBumping(data, derivatives_Bumping, priceSwap);
+
+    // aad
+    auto derivatives_aad = SwapData{};
+    auto actual = priceWithAAD(data, derivatives_aad, priceSwap);
+
+    // compare
+    QL_CHECK_CLOSE(expected, actual, 1e-9);
+    QL_CHECK_CLOSE(derivatives_Bumping.n, derivatives_aad.n, 1e-3);
+    QL_CHECK_CLOSE(derivatives_Bumping.s, derivatives_aad.s, 1e-3);
+    QL_CHECK_CLOSE(derivatives_Bumping.g, derivatives_aad.g, 1e-3);
+    QL_CHECK_CLOSE(derivatives_Bumping.v, derivatives_aad.v, 1e-3);
+}
+
+test_suite* SwapXadTest::suite() {
+    auto* suite = BOOST_TEST_SUITE("swap derivatives tests");
+
+    suite->add(QLXAD_TEST_CASE(&SwapXadTest::testSwapDerivatives));
+
+    return suite;
+}

--- a/test-suite/swap_xad.hpp
+++ b/test-suite/swap_xad.hpp
@@ -1,8 +1,10 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*
- Copyright (C) 2005 Klaus Spanderen
- Copyright (C) 2022 Xcelerit
+ Copyright (C) 2003, 2004 Ferdinando Ametrano
+ Copyright (C) 2005, 2007 StatPro Italia srl
+ Copyright (C) 2005 Joseph Wang
+ Copyright (C) 2023 Xcelerit
 
  This file is part of QuantLib / XAD integration module.
  It is modified from QuantLib, a free-software/open-source library
@@ -23,8 +25,8 @@
 
 #include <boost/test/unit_test.hpp>
 
-class BatesModelXadTest {
+class SwapXadTest {
   public:
-    static void testBatesModelDerivatives();
+    static void testSwapDerivatives();
     static boost::unit_test_framework::test_suite* suite();
 };

--- a/test-suite/utilities_xad.cpp
+++ b/test-suite/utilities_xad.cpp
@@ -19,17 +19,18 @@
 */
 
 #include "utilities_xad.hpp"
-#include <ql/instruments/payoffs.hpp>
 #include <ql/indexes/indexmanager.hpp>
-#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/instruments/payoffs.hpp>
 #include <ql/termstructures/volatility/equityfx/blackconstantvol.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/time/calendars/nullcalendar.hpp>
 
-#define CHECK_DOWNCAST(Derived,Description) { \
-    ext::shared_ptr<Derived> hd = ext::dynamic_pointer_cast<Derived>(h); \
-    if (hd) \
-        return Description; \
-}
+#define CHECK_DOWNCAST(Derived, Description)                                 \
+    {                                                                        \
+        ext::shared_ptr<Derived> hd = ext::dynamic_pointer_cast<Derived>(h); \
+        if (hd)                                                              \
+            return Description;                                              \
+    }
 
 namespace QuantLib {
 
@@ -59,69 +60,55 @@ namespace QuantLib {
 
 
     ext::shared_ptr<YieldTermStructure>
-    flatRate(const Date& today,
-             const ext::shared_ptr<Quote>& forward,
-             const DayCounter& dc) {
+    flatRate(const Date& today, const ext::shared_ptr<Quote>& forward, const DayCounter& dc) {
         return ext::shared_ptr<YieldTermStructure>(
-                          new FlatForward(today, Handle<Quote>(forward), dc));
+            new FlatForward(today, Handle<Quote>(forward), dc));
     }
 
     ext::shared_ptr<YieldTermStructure>
     flatRate(const Date& today, Rate forward, const DayCounter& dc) {
-        return flatRate(
-               today, ext::shared_ptr<Quote>(new SimpleQuote(forward)), dc);
+        return flatRate(today, ext::shared_ptr<Quote>(new SimpleQuote(forward)), dc);
     }
 
-    ext::shared_ptr<YieldTermStructure>
-    flatRate(const ext::shared_ptr<Quote>& forward,
-             const DayCounter& dc) {
+    ext::shared_ptr<YieldTermStructure> flatRate(const ext::shared_ptr<Quote>& forward,
+                                                 const DayCounter& dc) {
         return ext::shared_ptr<YieldTermStructure>(
-              new FlatForward(0, NullCalendar(), Handle<Quote>(forward), dc));
+            new FlatForward(0, NullCalendar(), Handle<Quote>(forward), dc));
     }
 
-    ext::shared_ptr<YieldTermStructure>
-    flatRate(Rate forward, const DayCounter& dc) {
-        return flatRate(ext::shared_ptr<Quote>(new SimpleQuote(forward)),
-                        dc);
+    ext::shared_ptr<YieldTermStructure> flatRate(Rate forward, const DayCounter& dc) {
+        return flatRate(ext::shared_ptr<Quote>(new SimpleQuote(forward)), dc);
     }
 
 
     ext::shared_ptr<BlackVolTermStructure>
-    flatVol(const Date& today,
-            const ext::shared_ptr<Quote>& vol,
-            const DayCounter& dc) {
-        return ext::shared_ptr<BlackVolTermStructure>(new
-            BlackConstantVol(today, NullCalendar(), Handle<Quote>(vol), dc));
+    flatVol(const Date& today, const ext::shared_ptr<Quote>& vol, const DayCounter& dc) {
+        return ext::shared_ptr<BlackVolTermStructure>(
+            new BlackConstantVol(today, NullCalendar(), Handle<Quote>(vol), dc));
     }
 
     ext::shared_ptr<BlackVolTermStructure>
-    flatVol(const Date& today, Volatility vol,
-            const DayCounter& dc) {
-        return flatVol(today,
-                       ext::shared_ptr<Quote>(new SimpleQuote(vol)),
-                       dc);
+    flatVol(const Date& today, Volatility vol, const DayCounter& dc) {
+        return flatVol(today, ext::shared_ptr<Quote>(new SimpleQuote(vol)), dc);
     }
 
-    ext::shared_ptr<BlackVolTermStructure>
-    flatVol(const ext::shared_ptr<Quote>& vol,
-            const DayCounter& dc) {
-        return ext::shared_ptr<BlackVolTermStructure>(new
-            BlackConstantVol(0, NullCalendar(), Handle<Quote>(vol), dc));
+    ext::shared_ptr<BlackVolTermStructure> flatVol(const ext::shared_ptr<Quote>& vol,
+                                                   const DayCounter& dc) {
+        return ext::shared_ptr<BlackVolTermStructure>(
+            new BlackConstantVol(0, NullCalendar(), Handle<Quote>(vol), dc));
     }
 
-    ext::shared_ptr<BlackVolTermStructure>
-    flatVol(Volatility vol,
-            const DayCounter& dc) {
+    ext::shared_ptr<BlackVolTermStructure> flatVol(Volatility vol, const DayCounter& dc) {
         return flatVol(ext::shared_ptr<Quote>(new SimpleQuote(vol)), dc);
     }
 
 
     Real relativeError(Real x1, Real x2, Real reference) {
         if (reference != 0.0)
-            return std::fabs(x1-x2)/reference;
+            return std::fabs(x1 - x2) / reference;
         else
             // fall back to absolute error
-            return std::fabs(x1-x2);
+            return std::fabs(x1 - x2);
     }
 
 

--- a/test-suite/utilities_xad.hpp
+++ b/test-suite/utilities_xad.hpp
@@ -21,21 +21,20 @@
 
 #pragma once
 
-#include <boost/algorithm/string/replace.hpp>
-
-#include <ql/instruments/payoffs.hpp>
 #include <ql/exercise.hpp>
-#include <ql/termstructures/yieldtermstructure.hpp>
-#include <ql/termstructures/volatility/equityfx/blackvoltermstructure.hpp>
-#include <ql/quote.hpp>
-#include <ql/patterns/observable.hpp>
-#include <ql/time/daycounters/actual365fixed.hpp>
 #include <ql/functional.hpp>
+#include <ql/instruments/payoffs.hpp>
+#include <ql/patterns/observable.hpp>
+#include <ql/quote.hpp>
+#include <ql/termstructures/volatility/equityfx/blackvoltermstructure.hpp>
+#include <ql/termstructures/yieldtermstructure.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
+#include <boost/algorithm/string/replace.hpp>
 #include <boost/test/unit_test.hpp>
 #if BOOST_VERSION < 105900
-#include <boost/test/floating_point_comparison.hpp>
+#    include <boost/test/floating_point_comparison.hpp>
 #else
-#include <boost/test/tools/floating_point_comparison.hpp>
+#    include <boost/test/tools/floating_point_comparison.hpp>
 #endif
 #include <cmath>
 #include <iomanip>
@@ -61,12 +60,12 @@ namespace QuantLib {
 
 using QuantLib::value;
 
-#define QL_CHECK_SMALL(FPV, T)  BOOST_CHECK_SMALL(value(FPV), value(T))
+#define QL_CHECK_SMALL(FPV, T) BOOST_CHECK_SMALL(value(FPV), value(T))
 #define QL_CHECK_CLOSE(L, R, T) BOOST_CHECK_CLOSE(value(L), value(R), value(T))
 
 
 // This makes it easier to use array literals (for new code, use std::vector though)
-#define LENGTH(a) (sizeof(a)/sizeof(a[0]))
+#define LENGTH(a) (sizeof(a) / sizeof(a[0]))
 
 // make test names pretty before registering them
 #define QLXAD_TEST_CASE(f)                                        \
@@ -93,6 +92,7 @@ namespace QuantLib {
         // used to avoid no-assertion messages in Boost 1.35
         class quantlib_test_case {
             ext::function<void()> test_;
+
           public:
             template <class F>
             explicit quantlib_test_case(F test) : test_(test) {}
@@ -103,17 +103,15 @@ namespace QuantLib {
                 Date after = Settings::instance().evaluationDate();
                 if (before != after)
                     BOOST_ERROR("Evaluation date not reset"
-                                << "\n  before: " << before
-                                << "\n  after:  " << after);
+                                << "\n  before: " << before << "\n  after:  " << after);
             }
-            #if BOOST_VERSION <= 105300
+#if BOOST_VERSION <= 105300
             // defined to avoid unused-variable warnings. It doesn't
             // work after Boost 1.53 because the functions were
             // overloaded and the address can't be resolved.
-            void _use_check(
-                    const void* = &boost::test_tools::check_is_close,
-                    const void* = &boost::test_tools::check_is_small) const {}
-            #endif
+            void _use_check(const void* = &boost::test_tools::check_is_close,
+                            const void* = &boost::test_tools::check_is_small) const {}
+#endif
         };
 
     }
@@ -123,48 +121,34 @@ namespace QuantLib {
 
 
     ext::shared_ptr<YieldTermStructure>
-    flatRate(const Date& today,
-             const ext::shared_ptr<Quote>& forward,
-             const DayCounter& dc);
+    flatRate(const Date& today, const ext::shared_ptr<Quote>& forward, const DayCounter& dc);
 
     ext::shared_ptr<YieldTermStructure>
-    flatRate(const Date& today,
-             Rate forward,
-             const DayCounter& dc);
+    flatRate(const Date& today, Rate forward, const DayCounter& dc);
 
-    ext::shared_ptr<YieldTermStructure>
-    flatRate(const ext::shared_ptr<Quote>& forward,
-             const DayCounter& dc);
+    ext::shared_ptr<YieldTermStructure> flatRate(const ext::shared_ptr<Quote>& forward,
+                                                 const DayCounter& dc);
 
-    ext::shared_ptr<YieldTermStructure>
-    flatRate(Rate forward,
-             const DayCounter& dc);
+    ext::shared_ptr<YieldTermStructure> flatRate(Rate forward, const DayCounter& dc);
 
 
     ext::shared_ptr<BlackVolTermStructure>
-    flatVol(const Date& today,
-            const ext::shared_ptr<Quote>& volatility,
-            const DayCounter& dc);
+    flatVol(const Date& today, const ext::shared_ptr<Quote>& volatility, const DayCounter& dc);
 
     ext::shared_ptr<BlackVolTermStructure>
-    flatVol(const Date& today,
-            Volatility volatility,
-            const DayCounter& dc);
+    flatVol(const Date& today, Volatility volatility, const DayCounter& dc);
 
-    ext::shared_ptr<BlackVolTermStructure>
-    flatVol(const ext::shared_ptr<Quote>& volatility,
-            const DayCounter& dc);
+    ext::shared_ptr<BlackVolTermStructure> flatVol(const ext::shared_ptr<Quote>& volatility,
+                                                   const DayCounter& dc);
 
-    ext::shared_ptr<BlackVolTermStructure>
-    flatVol(Volatility volatility,
-            const DayCounter& dc);
+    ext::shared_ptr<BlackVolTermStructure> flatVol(Volatility volatility, const DayCounter& dc);
 
 
     Real relativeError(Real x1, Real x2, Real reference);
 
-    //bool checkAbsError(Real x1, Real x2, Real tolerance){
-    //    return std::fabs(x1 - x2) < tolerance;
-    //};
+    // bool checkAbsError(Real x1, Real x2, Real tolerance){
+    //     return std::fabs(x1 - x2) < tolerance;
+    // };
 
     class Flag : public QuantLib::Observer {
       private:
@@ -178,14 +162,14 @@ namespace QuantLib {
         void update() override { raise(); }
     };
 
-    template<class Iterator>
+    template <class Iterator>
     Real norm(const Iterator& begin, const Iterator& end, Real h) {
         // squared values
-        std::vector<Real> f2(end-begin);
+        std::vector<Real> f2(end - begin);
         std::transform(begin, end, begin, f2.begin(), std::multiplies<>());
         // numeric integral of f^2
-        Real I = h * (std::accumulate(f2.begin(),f2.end(),Real(0.0))
-                      - 0.5*f2.front() - 0.5*f2.back());
+        Real I = h * (std::accumulate(f2.begin(), f2.end(), Real(0.0)) - 0.5 * f2.front() -
+                      0.5 * f2.back());
         return std::sqrt(I);
     }
 
@@ -226,7 +210,7 @@ namespace QuantLib {
     std::ostream& operator<<(std::ostream& out, const vector_streamer<T>& s) {
         out << "{ ";
         if (!s.v.empty()) {
-            for (size_t n=0; n<s.v.size()-1; ++n)
+            for (size_t n = 0; n < s.v.size() - 1; ++n)
                 out << s.v[n] << ", ";
             out << s.v.back();
         }
@@ -236,4 +220,3 @@ namespace QuantLib {
 
 
 }
-


### PR DESCRIPTION
## New Samples

This PR adds a set of new samples for calculating sensitivities with XAD in QuantLib. They are adaptions of the original QuantLib Examples to demonstrate XAD usage.

## Benchmarking

Further, benchmarking performance versus the plain `double` version of the same sample is now possible for 4 of the samples. Performance for plain pricing as well as sensitivities calculation is measured, averaged over a number of iterations. Using the added CMake option `QLXAD_DISABLE_AAD` allows to switch to `double`-only mode, where the same sample is compiled without XAD support. Therefore, performance versus plain `double` evaluation and also versus a finite-difference based sensitivity calculation can be measured.

## New Tests

The adjoint test suite has also been extended to include more pricers, comparing XAD-based sensitivities to finite difference to ensure correct results.

## CI/CD

The CI/CD workflow has been adapted to build on all platforms with both XAD enabled and disabled, to ensure the code is working in call cases.